### PR TITLE
feat(middleware): forward product on user-flow authorization

### DIFF
--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -211,9 +211,9 @@ func NewAuthClient(address string, enabled bool, logger *log.Logger) *AuthClient
 }
 
 // Authorize is a middleware function for the Fiber framework that checks if a user is authorized to perform a specific action on a resource.
-// It sends a POST request to the authorization service with the subject, resource, and action details.
+// product identifies the product/application owning the route (e.g. "midaz"); it builds the M2M role and is forwarded for user-flow isolation.
 // If the user is authorized, the request is passed to the next handler; otherwise, a 403 Forbidden status is returned.
-func (auth *AuthClient) Authorize(sub, resource, action string) fiber.Handler {
+func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		ctx := tracing.ExtractHTTPContext(c.UserContext(), c)
 
@@ -237,7 +237,7 @@ func (auth *AuthClient) Authorize(sub, resource, action string) fiber.Handler {
 			return c.Status(http.StatusUnauthorized).SendString("Missing Token")
 		}
 
-		if authorized, statusCode, err := auth.checkAuthorization(ctx, sub, resource, action, accessToken); err != nil {
+		if authorized, statusCode, err := auth.checkAuthorization(ctx, product, resource, action, accessToken); err != nil {
 			var commonsErr commons.Response
 			if errors.As(err, &commonsErr) {
 				span.End()
@@ -261,7 +261,10 @@ func (auth *AuthClient) Authorize(sub, resource, action string) fiber.Handler {
 }
 
 // checkAuthorization sends an authorization request to the external service and returns whether the action is authorized.
-func (auth *AuthClient) checkAuthorization(ctx context.Context, sub, resource, action, accessToken string) (bool, int, error) {
+// product identifies the product/plugin owning the route. The subject is derived from it: M2M tokens map to the product's
+// editor role, while normal users are identified by their JWT (owner/userId) and the product is forwarded so the auth
+// service can isolate permissions by product. Empty product keeps the previous behavior.
+func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resource, action, accessToken string) (bool, int, error) {
 	_, tracer, reqID, _ := observability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "lib_auth.check_authorization")
@@ -295,9 +298,13 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, sub, resource, a
 
 	userType, _ := claims["type"].(string)
 
+	var sub string
+
 	if userType != normalUser {
-		sub = fmt.Sprintf("admin/%s-editor-role", sub)
+		// M2M: the subject is the product's editor role.
+		sub = fmt.Sprintf("admin/%s-editor-role", product)
 	} else {
+		// Normal user: the subject is the user identity from the JWT.
 		owner, _ := claims["owner"].(string)
 		if owner == "" {
 			logErrorf(ctx, auth.Logger, "Missing owner claim in token")
@@ -309,14 +316,18 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, sub, resource, a
 			return false, http.StatusUnauthorized, err
 		}
 
-		sub, _ = claims["sub"].(string)
-		sub = fmt.Sprintf("%s/%s", owner, sub)
+		userID, _ := claims["sub"].(string)
+		sub = fmt.Sprintf("%s/%s", owner, userID)
 	}
 
 	requestBody := map[string]string{
 		"sub":      sub,
 		"resource": resource,
 		"action":   action,
+	}
+
+	if userType == normalUser && product != "" {
+		requestBody["product"] = product
 	}
 
 	err = tracing.SetSpanAttributesFromValue(span, "app.request.payload", requestBody, nil)

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -102,21 +102,23 @@ func TestCheckAuthorization_NormalUser_SubjectConstruction(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "initial-sub", "resource", "action", token,
+		context.Background(), "midaz", "resource", "action", token,
 	)
 
 	require.NoError(t, err)
 	assert.True(t, authorized)
 	assert.Equal(t, http.StatusOK, statusCode)
 
-	// For normal-user, sub should be "owner/sub-from-jwt" (overrides the initial sub parameter).
+	// For normal-user, sub is the JWT identity "owner/userId", not the product.
 	assert.Equal(t, "acme-org/user123", capturedBody["sub"])
+	// The product is forwarded so the auth service can isolate by product.
+	assert.Equal(t, "midaz", capturedBody["product"])
 }
 
 func TestCheckAuthorization_ApplicationUser_SubjectConstruction(t *testing.T) {
 	t.Parallel()
 
-	// Documents the current behavior: non-normal-user types get "admin/<initial-sub>-editor-role".
+	// Documents the current behavior: non-normal-user types get "admin/<product>-editor-role".
 	var capturedBody map[string]string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -157,9 +159,11 @@ func TestCheckAuthorization_ApplicationUser_SubjectConstruction(t *testing.T) {
 	assert.True(t, authorized)
 	assert.Equal(t, http.StatusOK, statusCode)
 
-	// BUG: hardcodes "admin/" prefix. The sub parameter is used as-is with the
-	// "admin/<sub>-editor-role" pattern, regardless of the actual user type.
+	// For M2M, the subject is built from the product: "admin/<product>-editor-role".
 	assert.Equal(t, "admin/my-app-editor-role", capturedBody["sub"])
+	// Product is NOT forwarded for non-normal-user tokens.
+	_, hasProduct := capturedBody["product"]
+	assert.False(t, hasProduct)
 }
 
 func TestCheckAuthorization_MissingOwnerClaim(t *testing.T) {


### PR DESCRIPTION
## Contexto

Lado **produtor** do contrato de isolamento de permissão por produto no fluxo de usuário. O lado receptor está em `plugin-access-manager` PR #134 (consome o campo `product` quando presente; sem ele, comportamento legado).

## Problema

O 1º argumento do `Authorize(sub, resource, action)` identifica o **produto** dono da rota (no M2M vira `admin/<sub>-editor-role`). Mas no token de **usuário normal** ele era **descartado**: o `sub` é sobrescrito por `owner/userId` do JWT, e o `checkAuthorization` mandava pro serviço de auth só `{sub, resource, action}` — sem discriminador de produto. Logo, o serviço não tinha como isolar permissões por produto no fluxo de usuário.

## Mudança

- `checkAuthorization` recebe um `product` e o encaminha como `"product"` no body **apenas para tokens de usuário normal**.
- **HTTP `Authorize`**: passa o 1º argumento (o produto).
- **gRPC**: passa `""` (a `Policy` ainda não carrega produto) → comportamento inalterado lá; isolação por produto no gRPC fica pra quando a `Policy` ganhar esse campo.
- **M2M**: nunca encaminha produto (o serviço de auth não usa no caminho M2M).
- `product` vazio preserva o comportamento anterior → o serviço de auth adota a isolação **incrementalmente**, serviço a serviço, conforme cada um sobe esta versão. Sem flag, sem cutover atômico.

## Testes

- Fluxo de usuário: assere que `product` é encaminhado no body.
- M2M: assere que `product` **não** é encaminhado.
- Demais testes de `checkAuthorization` atualizados pro novo parâmetro. 72 testes do pacote passam, `go vet` limpo.

## Rollout

Após release, `plugin-access-manager` (e demais consumidores) bumpam o `lib-auth` e passam a enviar o produto. Antes disso, tudo segue no caminho legado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)