### PR TITLE
refactor(grpc): name product arg consistently in policy interceptors

### DIFF
--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -317,6 +317,16 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 		}
 
 		userID, _ := claims["sub"].(string)
+		if userID == "" {
+			logErrorf(ctx, auth.Logger, "Missing sub claim in token")
+
+			err := errors.New("missing sub claim in token")
+
+			tracing.HandleSpanError(span, "Missing sub claim in token", err)
+
+			return false, http.StatusUnauthorized, err
+		}
+
 		sub = fmt.Sprintf("%s/%s", owner, userID)
 	}
 

--- a/auth/middleware/middlewareGRPC.go
+++ b/auth/middleware/middlewareGRPC.go
@@ -26,10 +26,13 @@ type Policy struct {
 	Action   string
 }
 
-// PolicyConfig binds gRPC methods to Policies and optional subject resolution.
+// PolicyConfig binds gRPC methods to Policies and optional product resolution.
 // - MethodPolicies keyed by info.FullMethod ("/pkg.Service/Method").
 // - DefaultPolicy used when a method mapping is absent.
-// - SubResolver derives the subject base (e.g., editor scope). Return "" when not applicable.
+// - SubResolver derives the product identifier (e.g., "midaz") that is forwarded
+//   to checkAuthorization as its product argument. For M2M tokens it becomes the
+//   subject "admin/<product>-editor-role"; for normal-user tokens it is forwarded
+//   for product isolation. Return "" when not applicable.
 type PolicyConfig struct {
 	MethodPolicies map[string]Policy
 	DefaultPolicy  *Policy
@@ -39,11 +42,11 @@ type PolicyConfig struct {
 // NewGRPCAuthUnaryPolicy authorizes unary RPCs via per-method Policy.
 // Behavior:
 // - Resolves the Policy by info.FullMethod; falls back to DefaultPolicy when provided.
-// - Optionally derives the subject using cfg.SubResolver (e.g., editor roles). Empty subject is valid.
+// - Optionally derives the product using cfg.SubResolver (e.g., "midaz"). Empty product is valid.
 // - Rejects missing tokens with codes.Unauthenticated; misconfiguration returns codes.Internal.
 // Telemetry:
 // - Sets app.request.request_id.
-// - Sets app.request.payload with {sub, resource, action} per standard.
+// - Sets app.request.payload with {product, resource, action} per standard.
 func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if auth == nil || !auth.Enabled || auth.Address == "" {
@@ -69,21 +72,23 @@ func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServer
 			return nil, status.Error(codes.Internal, "internal configuration error")
 		}
 
-		var sub string
+		// product is the resolved product identifier passed as checkAuthorization's
+		// product argument (M2M subject base and normal-user isolation key).
+		var product string
 
 		if cfg.SubResolver != nil {
 			var err error
 
-			sub, err = cfg.SubResolver(ctx, info.FullMethod, req)
+			product, err = cfg.SubResolver(ctx, info.FullMethod, req)
 			if err != nil {
-				tracing.HandleSpanError(span, "failed to resolve subject", err)
+				tracing.HandleSpanError(span, "failed to resolve product", err)
 
 				return nil, status.Error(codes.Internal, "internal configuration error")
 			}
 		}
 
 		payload := map[string]string{
-			"sub":      sub,
+			"product":  product,
 			"resource": pol.Resource,
 			"action":   pol.Action,
 		}
@@ -91,7 +96,7 @@ func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServer
 			tracing.HandleSpanError(span, "failed to set span payload", err)
 		}
 
-		authorized, httpStatus, err := auth.checkAuthorization(ctx, sub, pol.Resource, pol.Action, token)
+		authorized, httpStatus, err := auth.checkAuthorization(ctx, product, pol.Resource, pol.Action, token)
 		if err != nil {
 			return nil, grpcErrorFromHTTP(httpStatus)
 		}
@@ -248,18 +253,20 @@ func NewGRPCAuthStreamPolicy(auth *AuthClient, cfg PolicyConfig) grpc.StreamServ
 			return status.Error(codes.Internal, "internal configuration error")
 		}
 
-		var sub string
+		// product is the resolved product identifier passed as checkAuthorization's
+		// product argument (M2M subject base and normal-user isolation key).
+		var product string
 
 		if cfg.SubResolver != nil {
 			var err error
 
-			sub, err = cfg.SubResolver(ctx, info.FullMethod, nil)
+			product, err = cfg.SubResolver(ctx, info.FullMethod, nil)
 			if err != nil {
 				return status.Error(codes.Internal, "internal configuration error")
 			}
 		}
 
-		authorized, httpStatus, err := auth.checkAuthorization(ctx, sub, pol.Resource, pol.Action, token)
+		authorized, httpStatus, err := auth.checkAuthorization(ctx, product, pol.Resource, pol.Action, token)
 		if err != nil {
 			return grpcErrorFromHTTP(httpStatus)
 		}

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -195,6 +195,87 @@ func TestCheckAuthorization_MissingOwnerClaim(t *testing.T) {
 	assert.Contains(t, err.Error(), "missing owner claim")
 }
 
+func TestCheckAuthorization_MissingSubClaim(t *testing.T) {
+	t.Parallel()
+
+	server := mockAuthServer(t, true, http.StatusOK)
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address: server.URL,
+		Enabled: true,
+		Logger:  &testLogger{},
+	}
+
+	// normal-user without "sub" claim must fail closed instead of emitting "<owner>/".
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		// "sub" is intentionally missing
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "midaz", "resource", "action", token,
+	)
+
+	require.Error(t, err)
+	assert.False(t, authorized)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Contains(t, err.Error(), "missing sub claim")
+}
+
+func TestCheckAuthorization_NormalUser_EmptyProduct_NotForwarded(t *testing.T) {
+	t.Parallel()
+
+	// With an empty product the previous behavior must be preserved: the subject
+	// is still the JWT identity and no "product" field is forwarded (gate-by-presence).
+	var capturedBody map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&capturedBody)
+		if err != nil {
+			t.Errorf("mock server: failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		resp := AuthResponse{Authorized: true}
+
+		encErr := json.NewEncoder(w).Encode(resp)
+		if encErr != nil {
+			t.Errorf("mock server: failed to encode response: %v", encErr)
+		}
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address: server.URL,
+		Enabled: true,
+		Logger:  &testLogger{},
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "", "resource", "action", token,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, authorized)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	// Subject is still the JWT identity, unchanged by the empty product.
+	assert.Equal(t, "acme-org/user123", capturedBody["sub"])
+	// No product forwarded when product is empty.
+	_, hasProduct := capturedBody["product"]
+	assert.False(t, hasProduct)
+}
+
 func TestCheckAuthorization_MockServerReturnsAuthorizedTrue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Pull Request Type

- [x] Refactor

## Summary

Clarity-only follow-up to the user-flow product-isolation change. When `checkAuthorization`'s second parameter was renamed `sub` → `product`, the HTTP `Authorize` caller was updated, but the gRPC unary/stream interceptors kept naming their local variable `sub` while passing it into the `product` slot. This made the gRPC call sites read as if they were passing a subject when they are actually passing the product identifier.

This PR renames the gRPC local to `product` and clarifies the `PolicyConfig.SubResolver` doc so the resolved value's role is explicit.

## What it is NOT

No behavior change. The resolved value was already the product identifier (e.g. `midaz`) — the same thing the HTTP path passes. For M2M it becomes the subject `admin/<product>-editor-role`; for normal-user it is forwarded as the isolation key.

The public field `PolicyConfig.SubResolver` and `SubFromMetadata` are **kept** (no exported API rename) to avoid breaking consumers.

## Why it's safe

- The gRPC `NewGRPCAuthUnaryPolicy`/`PolicyConfig` API is **not used by any service in production** (only referenced in planned docs), so there is no live path to regress.
- Real M2M calls go through HTTP `Authorize`, which uses the same positional slot — unchanged.
- Verified against a real M2M token (`type=application`) hitting the local access manager: the new code emits `admin/plugin-crm-editor-role` / `admin/onboarding-editor-role` / `admin/transaction-editor-role` — byte-identical to v2.8.0.

## Checklist

- [x] I have tested these changes locally.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [x] I have confirmed this code is ready for review.

## Notes

Targets `develop`. Should land before promoting `v2.9.0` to stable (PR #115).


---

## Update — also closes the remaining CodeRabbit threads

This PR now additionally addresses the two other review findings from the release diff:

- **Fail closed on missing `sub`** (Security thread): a normal-user JWT without a `sub` claim previously produced `"<owner>/"` and was sent as an identity-less principal. It is now rejected with 401, mirroring the existing missing-owner guard. Non-breaking — every legitimate user token has `sub`.
- **Regression coverage** (Maintainability thread): added `TestCheckAuthorization_MissingSubClaim` (rejects no-`sub`) and `TestCheckAuthorization_NormalUser_EmptyProduct_NotForwarded` (empty product preserves prior behavior, no product forwarded — gate-by-presence).

All tests green.
