### PR TITLE
refactor(middleware): cut checkAuthorization cyclomatic complexity

### DIFF
--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LerianStudio/lib-observability/tracing"
 	"github.com/LerianStudio/lib-observability/zap"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/LerianStudio/lib-commons/v5/commons"
 	libHTTP "github.com/LerianStudio/lib-commons/v5/commons/net/http"
@@ -264,6 +265,40 @@ func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handle
 // product identifies the product/plugin owning the route. The subject is derived from it: M2M tokens map to the product's
 // editor role, while normal users are identified by their JWT (owner/userId) and the product is forwarded so the auth
 // service can isolate permissions by product. Empty product keeps the previous behavior.
+// deriveSubject builds the authorization subject from the token claims.
+// For M2M tokens it is the product's editor role ("admin/<product>-editor-role");
+// for normal-user tokens it is the JWT identity ("<owner>/<userID>"), failing
+// closed with 401 when the owner or sub claim is missing.
+func (auth *AuthClient) deriveSubject(ctx context.Context, span trace.Span, claims jwt.MapClaims, userType, product string) (string, int, error) {
+	if userType != normalUser {
+		return fmt.Sprintf("admin/%s-editor-role", product), http.StatusOK, nil
+	}
+
+	owner, _ := claims["owner"].(string)
+	if owner == "" {
+		logErrorf(ctx, auth.Logger, "Missing owner claim in token")
+
+		err := errors.New("missing owner claim in token")
+
+		tracing.HandleSpanError(span, "Missing owner claim in token", err)
+
+		return "", http.StatusUnauthorized, err
+	}
+
+	userID, _ := claims["sub"].(string)
+	if userID == "" {
+		logErrorf(ctx, auth.Logger, "Missing sub claim in token")
+
+		err := errors.New("missing sub claim in token")
+
+		tracing.HandleSpanError(span, "Missing sub claim in token", err)
+
+		return "", http.StatusUnauthorized, err
+	}
+
+	return fmt.Sprintf("%s/%s", owner, userID), http.StatusOK, nil
+}
+
 func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resource, action, accessToken string) (bool, int, error) {
 	_, tracer, reqID, _ := observability.NewTrackingFromContext(ctx)
 
@@ -298,36 +333,9 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 
 	userType, _ := claims["type"].(string)
 
-	var sub string
-
-	if userType != normalUser {
-		// M2M: the subject is the product's editor role.
-		sub = fmt.Sprintf("admin/%s-editor-role", product)
-	} else {
-		// Normal user: the subject is the user identity from the JWT.
-		owner, _ := claims["owner"].(string)
-		if owner == "" {
-			logErrorf(ctx, auth.Logger, "Missing owner claim in token")
-
-			err := errors.New("missing owner claim in token")
-
-			tracing.HandleSpanError(span, "Missing owner claim in token", err)
-
-			return false, http.StatusUnauthorized, err
-		}
-
-		userID, _ := claims["sub"].(string)
-		if userID == "" {
-			logErrorf(ctx, auth.Logger, "Missing sub claim in token")
-
-			err := errors.New("missing sub claim in token")
-
-			tracing.HandleSpanError(span, "Missing sub claim in token", err)
-
-			return false, http.StatusUnauthorized, err
-		}
-
-		sub = fmt.Sprintf("%s/%s", owner, userID)
+	sub, statusCode, err := auth.deriveSubject(ctx, span, claims, userType, product)
+	if err != nil {
+		return false, statusCode, err
 	}
 
 	requestBody := map[string]string{

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -198,7 +198,11 @@ func TestCheckAuthorization_MissingOwnerClaim(t *testing.T) {
 func TestCheckAuthorization_MissingSubClaim(t *testing.T) {
 	t.Parallel()
 
-	server := mockAuthServer(t, true, http.StatusOK)
+	// The auth backend must never be reached: a missing-sub token has to fail
+	// closed in checkAuthorization before any request is made.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("auth backend must not be called when the sub claim is missing")
+	}))
 	defer server.Close()
 
 	auth := &AuthClient{


### PR DESCRIPTION
## Pull Request Type

- [x] Refactor

## Summary

CI lint (gocyclo via reviewdog) flagged `(*AuthClient).checkAuthorization` at cyclomatic complexity **17 (> 16)** after the fail-closed `sub` guard landed in #116.

This extracts the subject-derivation branch (M2M editor-role vs normal-user identity, including the owner/sub fail-closed guards) into a new helper `deriveSubject`, bringing `checkAuthorization` back to **15**.

## Why a separate PR

#116 was already merged into `develop` (and `v2.9.0-beta.2` was cut) before the lint fix was ready, so it lands as a small follow-up.

## Guarantees

- **No behavior change** — pure extraction; same branches, same 401 fail-closed semantics.
- `gocyclo -over 16` → clean.
- Build + full middleware test suite green (the existing `MissingSubClaim` / `MissingOwnerClaim` / empty-product tests still pass against the extracted helper).

## Notes

Should land in `develop` before promoting `v2.9.0` to stable (PR #115), so the release line is lint-clean.