### PR TITLE
feat: real M2M subject and token type whitelist

### DIFF
--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -47,8 +47,9 @@ type oauth2Token struct {
 }
 
 const (
-	normalUser string = "normal-user"
-	pluginName string = "plugin-auth"
+	normalUser  string = "normal-user"
+	application string = "application"
+	pluginName  string = "plugin-auth"
 )
 
 // sharedHTTPClient is a package-level HTTP client with a custom transport
@@ -212,7 +213,8 @@ func NewAuthClient(address string, enabled bool, logger *log.Logger) *AuthClient
 }
 
 // Authorize is a middleware function for the Fiber framework that checks if a user is authorized to perform a specific action on a resource.
-// product identifies the product/application owning the route (e.g. "midaz"); it builds the M2M role and is forwarded for user-flow isolation.
+// product identifies the product/application owning the route (e.g. "midaz"); it is forwarded only for normal-user flows so the auth service can
+// isolate permissions by product. M2M (application) tokens carry no product isolation and are identified by their own subject claim.
 // If the user is authorized, the request is passed to the next handler; otherwise, a 403 Forbidden status is returned.
 func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
@@ -261,42 +263,63 @@ func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handle
 	}
 }
 
-// checkAuthorization sends an authorization request to the external service and returns whether the action is authorized.
-// product identifies the product/plugin owning the route. The subject is derived from it: M2M tokens map to the product's
-// editor role, while normal users are identified by their JWT (owner/userId) and the product is forwarded so the auth
-// service can isolate permissions by product. Empty product keeps the previous behavior.
-// deriveSubject builds the authorization subject from the token claims.
-// For M2M tokens it is the product's editor role ("admin/<product>-editor-role");
-// for normal-user tokens it is the JWT identity ("<owner>/<userID>"), failing
-// closed with 401 when the owner or sub claim is missing.
-func (auth *AuthClient) deriveSubject(ctx context.Context, span trace.Span, claims jwt.MapClaims, userType, product string) (string, int, error) {
-	if userType != normalUser {
-		return fmt.Sprintf("admin/%s-editor-role", product), http.StatusOK, nil
-	}
+// deriveSubject builds the authorization subject from the token claims based on
+// the whitelisted token type. It fails closed (401) for any type outside
+// {normal-user, application}:
+//   - normal-user: the JWT identity ("<owner>/<userID>"), failing closed with 401
+//     when the owner or sub claim is missing.
+//   - application (M2M): the token's own sub claim (already in "<owner>/<name>"
+//     form), failing closed with 401 when sub is missing. No product-scoped role
+//     is fabricated, since M2M has no product isolation.
+//   - any other type (including empty/absent): rejected with 401.
+func (auth *AuthClient) deriveSubject(ctx context.Context, span trace.Span, claims jwt.MapClaims, userType string) (string, int, error) {
+	switch userType {
+	case normalUser:
+		owner, _ := claims["owner"].(string)
+		if owner == "" {
+			logErrorf(ctx, auth.Logger, "Missing owner claim in token")
 
-	owner, _ := claims["owner"].(string)
-	if owner == "" {
-		logErrorf(ctx, auth.Logger, "Missing owner claim in token")
+			err := errors.New("missing owner claim in token")
 
-		err := errors.New("missing owner claim in token")
+			tracing.HandleSpanError(span, "Missing owner claim in token", err)
 
-		tracing.HandleSpanError(span, "Missing owner claim in token", err)
+			return "", http.StatusUnauthorized, err
+		}
+
+		userID, _ := claims["sub"].(string)
+		if userID == "" {
+			logErrorf(ctx, auth.Logger, "Missing sub claim in token")
+
+			err := errors.New("missing sub claim in token")
+
+			tracing.HandleSpanError(span, "Missing sub claim in token", err)
+
+			return "", http.StatusUnauthorized, err
+		}
+
+		return fmt.Sprintf("%s/%s", owner, userID), http.StatusOK, nil
+	case application:
+		sub, _ := claims["sub"].(string)
+		if sub == "" {
+			logErrorf(ctx, auth.Logger, "Missing sub claim in application token")
+
+			err := errors.New("missing sub claim in token")
+
+			tracing.HandleSpanError(span, "Missing sub claim in application token", err)
+
+			return "", http.StatusUnauthorized, err
+		}
+
+		return sub, http.StatusOK, nil
+	default:
+		logErrorf(ctx, auth.Logger, "Unsupported token type: %q", userType)
+
+		err := errors.New("unsupported token type")
+
+		tracing.HandleSpanError(span, "Unsupported token type", err)
 
 		return "", http.StatusUnauthorized, err
 	}
-
-	userID, _ := claims["sub"].(string)
-	if userID == "" {
-		logErrorf(ctx, auth.Logger, "Missing sub claim in token")
-
-		err := errors.New("missing sub claim in token")
-
-		tracing.HandleSpanError(span, "Missing sub claim in token", err)
-
-		return "", http.StatusUnauthorized, err
-	}
-
-	return fmt.Sprintf("%s/%s", owner, userID), http.StatusOK, nil
 }
 
 func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resource, action, accessToken string) (bool, int, error) {
@@ -333,7 +356,7 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 
 	userType, _ := claims["type"].(string)
 
-	sub, statusCode, err := auth.deriveSubject(ctx, span, claims, userType, product)
+	sub, statusCode, err := auth.deriveSubject(ctx, span, claims, userType)
 	if err != nil {
 		return false, statusCode, err
 	}

--- a/auth/middleware/middlewareGRPC.go
+++ b/auth/middleware/middlewareGRPC.go
@@ -27,12 +27,13 @@ type Policy struct {
 }
 
 // PolicyConfig binds gRPC methods to Policies and optional product resolution.
-// - MethodPolicies keyed by info.FullMethod ("/pkg.Service/Method").
-// - DefaultPolicy used when a method mapping is absent.
-// - SubResolver derives the product identifier (e.g., "midaz") that is forwarded
-//   to checkAuthorization as its product argument. For M2M tokens it becomes the
-//   subject "admin/<product>-editor-role"; for normal-user tokens it is forwarded
-//   for product isolation. Return "" when not applicable.
+//   - MethodPolicies keyed by info.FullMethod ("/pkg.Service/Method").
+//   - DefaultPolicy used when a method mapping is absent.
+//   - SubResolver derives the product identifier (e.g., "midaz") passed to
+//     checkAuthorization as its product argument. It is forwarded only for
+//     normal-user tokens (product isolation); M2M (application) tokens carry no
+//     product isolation and are identified by their own subject claim. Return ""
+//     when not applicable.
 type PolicyConfig struct {
 	MethodPolicies map[string]Policy
 	DefaultPolicy  *Policy
@@ -45,8 +46,10 @@ type PolicyConfig struct {
 // - Optionally derives the product using cfg.SubResolver (e.g., "midaz"). Empty product is valid.
 // - Rejects missing tokens with codes.Unauthenticated; misconfiguration returns codes.Internal.
 // Telemetry:
-// - Sets app.request.request_id.
-// - Sets app.request.payload with {product, resource, action} per standard.
+//   - Sets app.request.request_id.
+//   - Sets app.request.payload with {resource, action}, including product only when
+//     it is actually forwarded to the auth service (normal-user flows with a
+//     non-empty product), mirroring the request body.
 func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		if auth == nil || !auth.Enabled || auth.Address == "" {
@@ -73,7 +76,8 @@ func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServer
 		}
 
 		// product is the resolved product identifier passed as checkAuthorization's
-		// product argument (M2M subject base and normal-user isolation key).
+		// product argument. It is forwarded only for normal-user flows; M2M
+		// (application) tokens carry no product isolation.
 		var product string
 
 		if cfg.SubResolver != nil {
@@ -87,11 +91,7 @@ func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServer
 			}
 		}
 
-		payload := map[string]string{
-			"product":  product,
-			"resource": pol.Resource,
-			"action":   pol.Action,
-		}
+		payload := authPayload(token, product, pol.Resource, pol.Action)
 		if err := tracing.SetSpanAttributesFromValue(span, "app.request.payload", payload, nil); err != nil {
 			tracing.HandleSpanError(span, "failed to set span payload", err)
 		}
@@ -209,6 +209,42 @@ func SubFromMetadata(key string) func(ctx context.Context, fullMethod string, re
 	}
 }
 
+// authPayload builds the telemetry payload mirroring the request body sent to the
+// auth service by checkAuthorization: product is included only when it is actually
+// forwarded (normal-user flows with a non-empty product).
+func authPayload(token, product, resource, action string) map[string]string {
+	payload := map[string]string{
+		"resource": resource,
+		"action":   action,
+	}
+
+	if tokenTypeClaim(token) == normalUser && product != "" {
+		payload["product"] = product
+	}
+
+	return payload
+}
+
+// tokenTypeClaim returns the "type" claim from an unverified JWT, or "" when the
+// token cannot be parsed. Best-effort and telemetry-only: the authorization
+// decision (and its fail-closed handling) still goes through checkAuthorization,
+// which re-parses and validates the token.
+func tokenTypeClaim(tokenString string) string {
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return ""
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return ""
+	}
+
+	t, _ := claims["type"].(string)
+
+	return t
+}
+
 // extractTenantClaims extracts tenant-related claims from a JWT without signature verification.
 // Returns tenantID, tenantSlug, and owner from the token's custom claims.
 // Used by gRPC interceptors to propagate tenant context to downstream services.
@@ -254,7 +290,8 @@ func NewGRPCAuthStreamPolicy(auth *AuthClient, cfg PolicyConfig) grpc.StreamServ
 		}
 
 		// product is the resolved product identifier passed as checkAuthorization's
-		// product argument (M2M subject base and normal-user isolation key).
+		// product argument. It is forwarded only for normal-user flows; M2M
+		// (application) tokens carry no product isolation.
 		var product string
 
 		if cfg.SubResolver != nil {

--- a/auth/middleware/middlewareGRPC_test.go
+++ b/auth/middleware/middlewareGRPC_test.go
@@ -2,7 +2,9 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	jwt "github.com/golang-jwt/jwt/v5"
@@ -747,6 +749,139 @@ func TestNewGRPCAuthUnaryPolicy_TenantPropagation(t *testing.T) {
 		assert.Empty(t, md.Get("md-tenant-slug"))
 		assert.Empty(t, md.Get("md-tenant-owner"))
 	})
+}
+
+// ---------------------------------------------------------------------------
+// authPayload - product gating in telemetry
+// ---------------------------------------------------------------------------
+
+func TestAuthPayload_ProductGating(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normal_user_with_product_includes_product", func(t *testing.T) {
+		t.Parallel()
+
+		token := createTestJWT(jwt.MapClaims{
+			"type":  "normal-user",
+			"owner": "acme-org",
+			"sub":   "user123",
+		})
+
+		payload := authPayload(token, "midaz", "resource", "read")
+
+		// resource/action are always present.
+		assert.Equal(t, "resource", payload["resource"])
+		assert.Equal(t, "read", payload["action"])
+		// product is forwarded for normal-user flows with a non-empty product.
+		assert.Equal(t, "midaz", payload["product"])
+	})
+
+	t.Run("application_omits_product", func(t *testing.T) {
+		t.Parallel()
+
+		token := createTestJWT(jwt.MapClaims{
+			"type": "application",
+			"name": "my-app",
+			"sub":  "acme-org/my-app",
+		})
+
+		payload := authPayload(token, "midaz", "resource", "read")
+
+		assert.Equal(t, "resource", payload["resource"])
+		assert.Equal(t, "read", payload["action"])
+		// M2M carries no product isolation, so product is not recorded.
+		_, hasProduct := payload["product"]
+		assert.False(t, hasProduct)
+	})
+
+	t.Run("normal_user_with_empty_product_omits_product", func(t *testing.T) {
+		t.Parallel()
+
+		token := createTestJWT(jwt.MapClaims{
+			"type":  "normal-user",
+			"owner": "acme-org",
+			"sub":   "user123",
+		})
+
+		payload := authPayload(token, "", "resource", "read")
+
+		assert.Equal(t, "resource", payload["resource"])
+		assert.Equal(t, "read", payload["action"])
+		// Empty product is never forwarded.
+		_, hasProduct := payload["product"]
+		assert.False(t, hasProduct)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NewGRPCAuthUnaryPolicy - M2M subject construction
+// ---------------------------------------------------------------------------
+
+func TestNewGRPCAuthUnaryPolicy_ApplicationSubject(t *testing.T) {
+	t.Parallel()
+
+	// An application (M2M) token flowing through the gRPC unary path must be
+	// identified by its real sub claim, with product not forwarded in the body.
+	var capturedBody map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Errorf("mock server: failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(AuthResponse{Authorized: true}); err != nil {
+			t.Errorf("mock server: failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address: server.URL,
+		Enabled: true,
+		Logger:  &testLogger{},
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type": "application",
+		"name": "my-app",
+		"sub":  "acme-org/my-app",
+	})
+
+	defaultPol := Policy{Resource: "res", Action: "read"}
+	cfg := PolicyConfig{
+		DefaultPolicy: &defaultPol,
+		SubResolver: func(_ context.Context, _ string, _ any) (string, error) {
+			return "midaz", nil
+		},
+	}
+	interceptor := NewGRPCAuthUnaryPolicy(auth, cfg)
+
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("authorization", "Bearer "+token),
+	)
+
+	called := false
+	handler := func(_ context.Context, _ any) (any, error) {
+		called = true
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{FullMethod: "/pkg.Service/DoThing"}
+
+	resp, err := interceptor(ctx, "req", info, handler)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+	assert.True(t, called)
+
+	// Subject is the real sub of the application token.
+	assert.Equal(t, "acme-org/my-app", capturedBody["sub"])
+	// Product is not forwarded for M2M tokens.
+	_, hasProduct := capturedBody["product"]
+	assert.False(t, hasProduct)
 }
 
 // ---------------------------------------------------------------------------

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -118,7 +118,8 @@ func TestCheckAuthorization_NormalUser_SubjectConstruction(t *testing.T) {
 func TestCheckAuthorization_ApplicationUser_SubjectConstruction(t *testing.T) {
 	t.Parallel()
 
-	// Documents the current behavior: non-normal-user types get "admin/<product>-editor-role".
+	// Application (M2M) tokens are identified by their real sub claim (already in
+	// "owner/name" form); no product-editor-role is fabricated and product is not forwarded.
 	var capturedBody map[string]string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -159,8 +160,8 @@ func TestCheckAuthorization_ApplicationUser_SubjectConstruction(t *testing.T) {
 	assert.True(t, authorized)
 	assert.Equal(t, http.StatusOK, statusCode)
 
-	// For M2M, the subject is built from the product: "admin/<product>-editor-role".
-	assert.Equal(t, "admin/my-app-editor-role", capturedBody["sub"])
+	// For M2M, the subject is the real sub claim of the application token.
+	assert.Equal(t, "app-sub", capturedBody["sub"])
 	// Product is NOT forwarded for non-normal-user tokens.
 	_, hasProduct := capturedBody["product"]
 	assert.False(t, hasProduct)
@@ -401,28 +402,14 @@ func TestCheckAuthorization_InvalidToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, statusCode)
 }
 
-func TestCheckAuthorization_EmptyTypeClaim_TreatedAsNonNormalUser(t *testing.T) {
+func TestCheckAuthorization_EmptyTypeClaim_Rejected(t *testing.T) {
 	t.Parallel()
 
-	// When the "type" claim is empty or absent, userType != normalUser,
-	// so the code takes the admin/ branch.
-	var capturedBody map[string]string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := json.NewDecoder(r.Body).Decode(&capturedBody)
-		if err != nil {
-			t.Errorf("mock server: failed to decode request body: %v", err)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-
-		resp := AuthResponse{Authorized: true}
-
-		encErr := json.NewEncoder(w).Encode(resp)
-		if encErr != nil {
-			t.Errorf("mock server: failed to encode response: %v", encErr)
-		}
+	// When the "type" claim is empty or absent it is not in the whitelist
+	// {normal-user, application}, so the request must fail closed with 401 and
+	// the auth backend must never be reached.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("auth backend must not be called when the type claim is absent")
 	}))
 	defer server.Close()
 
@@ -432,7 +419,7 @@ func TestCheckAuthorization_EmptyTypeClaim_TreatedAsNonNormalUser(t *testing.T) 
 		Logger:  &testLogger{},
 	}
 
-	// No "type" claim at all -> defaults to empty string -> non-normal-user path
+	// No "type" claim at all -> defaults to empty string -> not whitelisted.
 	token := createTestJWT(jwt.MapClaims{
 		"sub": "some-app",
 	})
@@ -441,10 +428,74 @@ func TestCheckAuthorization_EmptyTypeClaim_TreatedAsNonNormalUser(t *testing.T) 
 		context.Background(), "some-app", "resource", "action", token,
 	)
 
-	require.NoError(t, err)
-	assert.True(t, authorized)
-	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Equal(t, "admin/some-app-editor-role", capturedBody["sub"])
+	require.Error(t, err)
+	assert.False(t, authorized)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Contains(t, err.Error(), "unsupported token type")
+}
+
+func TestCheckAuthorization_ApplicationUser_MissingSubClaim_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	// An application token without a "sub" claim must fail closed with 401 before
+	// the auth backend is reached.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("auth backend must not be called when the application sub claim is missing")
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address: server.URL,
+		Enabled: true,
+		Logger:  &testLogger{},
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type": "application",
+		"name": "my-app",
+		// "sub" is intentionally missing
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "my-app", "resource", "action", token,
+	)
+
+	require.Error(t, err)
+	assert.False(t, authorized)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Contains(t, err.Error(), "missing sub claim")
+}
+
+func TestCheckAuthorization_NonCanonicalType_Rejected(t *testing.T) {
+	t.Parallel()
+
+	// Any type outside the whitelist {normal-user, application} must fail closed
+	// with 401 and never reach the auth backend.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("auth backend must not be called for a non-canonical token type")
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address: server.URL,
+		Enabled: true,
+		Logger:  &testLogger{},
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "service-account",
+		"owner": "acme-org",
+		"sub":   "svc-1",
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "midaz", "resource", "action", token,
+	)
+
+	require.Error(t, err)
+	assert.False(t, authorized)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Contains(t, err.Error(), "unsupported token type")
 }
 
 func TestCheckAuthorization_MockServerDown(t *testing.T) {


### PR DESCRIPTION
## What

Item 17 / Phase 1 (lib-auth). `deriveSubject` (auth/middleware) stops fabricating the synthetic M2M subject `admin/{product}-editor-role` and hardens token-type handling into an explicit fail-closed whitelist.

## Changes

- **`deriveSubject` → 3-way switch on token type:**
  - `normal-user`: unchanged (`owner/sub`, fail-closed 401 if owner/sub missing).
  - `application` (M2M): uses the token's real `sub` claim instead of the fabricated `admin/{product}-editor-role`. The enforcer ignores that subject and resolves roles dynamically (Tier A), so carrying the real identity is the honest choice (audit/telemetry).
  - any other type (incl. empty/absent): **fail-closed 401 before the authorize call** — closes the asymmetry where an empty type fell into the M2M path.
- `product` dropped from `deriveSubject`; still forwarded only for normal-user at `checkAuthorization` (M2M has no product isolation by design — unchanged).
- gRPC telemetry payload aligned to the actual request body (product only when forwarded).
- Tests: M2M subject rewritten, empty-type→rejected, new fail-closed cases (app missing sub, non-canonical type), gRPC M2M subject, and `authPayload` gating.

## Validation

`go build` / `go vet` / `gofmt` / `golangci-lint` clean; `go test ./auth/...` green. Adversarial security + logic reviews: both PASS, 0 defects.

## ⚠️ Deploy order

plugin-auth with #224 (dynamic M2M enforce) must be deployed BEFORE bumping lib-auth in consumers — the old enforcer still expects `admin/...`. Repeat the token `type` decode in production before rolling out the bump.

Part of Item 17 (Tier A), Phase 1.