### PR TITLE
feat(middleware): expose M2M identity via request context

### DIFF
--- a/auth/middleware/m2m.go
+++ b/auth/middleware/m2m.go
@@ -20,13 +20,18 @@ import (
 	jwt "github.com/golang-jwt/jwt/v5"
 )
 
-// Fiber locals keys under which RequireM2M stores the authenticated application
-// identity for downstream handlers. Read them via the typed helpers
-// (M2MSubjectFromContext / M2MClientIDFromContext), not the raw keys.
-const (
-	contextKeyM2MSubject  = "lib_auth.m2m.subject"
-	contextKeyM2MClientID = "lib_auth.m2m.client_id"
-)
+// M2MIdentity is the authenticated application identity extracted from a verified
+// M2M token. RequireM2M stores it on the request Go context; read it back with
+// M2MIdentityFromContext.
+type M2MIdentity struct {
+	Subject  string // "sub" claim, "<owner>/<id>" form
+	ClientID string // "azp" claim (the Casdoor application clientId)
+}
+
+// m2mIdentityContextKey is the unexported, typed key under which RequireM2M stores
+// the M2MIdentity on the request context. A dedicated type (rather than a string)
+// avoids collisions with any other context value.
+type m2mIdentityContextKey struct{}
 
 // M2MAuthenticator authenticates machine-to-machine (application) callers by
 // verifying a Casdoor-issued RS256 access token offline against an injected
@@ -96,8 +101,10 @@ func NewM2MAuthenticator(certificatePEM, expectedIssuer string, enabled bool, lo
 
 // RequireM2M is a Fiber middleware that rejects any request not carrying a
 // valid, unexpired, RS256-signed Casdoor application (M2M) token. On success the
-// application identity is stored in the request locals (see
-// M2MSubjectFromContext / M2MClientIDFromContext) and the request proceeds.
+// application identity is stored on the request Go context (readable via
+// M2MIdentityFromContext, framework-agnostically, by any downstream handler —
+// fiber-native via c.Context(), humafiber-derived, or gRPC) and the request
+// proceeds.
 //
 // All failure modes fail closed:
 //   - missing token                          -> 401 Unauthorized
@@ -135,8 +142,10 @@ func (m *M2MAuthenticator) RequireM2M() fiber.Handler {
 		subject, _ := claims["sub"].(string)
 		clientID, _ := claims["azp"].(string)
 
-		c.Locals(contextKeyM2MSubject, subject)
-		c.Locals(contextKeyM2MClientID, clientID)
+		// Store the identity on the request Go context (derived from c.Context(),
+		// NOT the tracing ctx) so this adds only the identity value without altering
+		// span/tracing topology. Downstream handlers read it via M2MIdentityFromContext.
+		c.SetContext(context.WithValue(c.Context(), m2mIdentityContextKey{}, M2MIdentity{Subject: subject, ClientID: clientID}))
 
 		span.SetAttributes(
 			attribute.String("app.auth.m2m.subject", subject),
@@ -222,18 +231,12 @@ func (m *M2MAuthenticator) verify(ctx context.Context, span trace.Span, accessTo
 	return claims, http.StatusOK, nil
 }
 
-// M2MSubjectFromContext returns the authenticated application subject (the "sub"
-// claim, "<owner>/<id>" form) stored by RequireM2M, or ("", false) when absent.
-func M2MSubjectFromContext(c fiber.Ctx) (string, bool) {
-	v, ok := c.Locals(contextKeyM2MSubject).(string)
+// M2MIdentityFromContext returns the authenticated M2M identity that RequireM2M
+// stored on the request context, or (zero, false) when absent. A stored identity
+// with an empty Subject is reported as absent so callers never treat a
+// half-populated identity as authenticated.
+func M2MIdentityFromContext(ctx context.Context) (M2MIdentity, bool) {
+	id, ok := ctx.Value(m2mIdentityContextKey{}).(M2MIdentity)
 
-	return v, ok && v != ""
-}
-
-// M2MClientIDFromContext returns the authenticated application client id (the
-// "azp" claim) stored by RequireM2M, or ("", false) when absent.
-func M2MClientIDFromContext(c fiber.Ctx) (string, bool) {
-	v, ok := c.Locals(contextKeyM2MClientID).(string)
-
-	return v, ok && v != ""
+	return id, ok && id.Subject != ""
 }

--- a/auth/middleware/m2m.go
+++ b/auth/middleware/m2m.go
@@ -237,6 +237,9 @@ func (m *M2MAuthenticator) verify(ctx context.Context, span trace.Span, accessTo
 // half-populated identity as authenticated.
 func M2MIdentityFromContext(ctx context.Context) (M2MIdentity, bool) {
 	id, ok := ctx.Value(m2mIdentityContextKey{}).(M2MIdentity)
+	if !ok || id.Subject == "" {
+		return M2MIdentity{}, false
+	}
 
-	return id, ok && id.Subject != ""
+	return id, true
 }

--- a/auth/middleware/m2m_test.go
+++ b/auth/middleware/m2m_test.go
@@ -91,16 +91,17 @@ func newTestM2MAuthenticatorWithIssuer(t *testing.T, pubPEM, issuer string) *M2M
 }
 
 // newTestM2MApp builds a Fiber app whose single route is gated by RequireM2M and
-// echoes the authenticated identity back through response headers.
+// echoes the authenticated identity back through response headers. The downstream
+// handler reads the identity from the framework-agnostic Go context
+// (c.Context()), the same path humafiber-derived handlers rely on.
 func newTestM2MApp(m *M2MAuthenticator) *fiber.App {
 	app := fiber.New()
 
 	app.Put("/declarations/:slug", m.RequireM2M(), func(c fiber.Ctx) error {
-		sub, _ := M2MSubjectFromContext(c)
-		clientID, _ := M2MClientIDFromContext(c)
+		id, _ := M2MIdentityFromContext(c.Context())
 
-		c.Set("X-M2M-Subject", sub)
-		c.Set("X-M2M-Client-Id", clientID)
+		c.Set("X-M2M-Subject", id.Subject)
+		c.Set("X-M2M-Client-Id", id.ClientID)
 
 		return c.SendStatus(http.StatusOK)
 	})
@@ -394,6 +395,9 @@ func TestRequireM2M_MissingToken_Unauthorized(t *testing.T) {
 func TestRequireM2M_ValidToken_AllowsAndExposesIdentity(t *testing.T) {
 	t.Parallel()
 
+	// End-to-end proof that RequireM2M propagates the identity onto the Go
+	// context: the downstream handler reads it via M2MIdentityFromContext(c.Context())
+	// (see newTestM2MApp), the same mechanism humafiber-derived handlers rely on.
 	key, pubPEM := newTestRSAKeyPEM(t)
 	app := newTestM2MApp(newTestM2MAuthenticator(t, pubPEM))
 
@@ -426,4 +430,46 @@ func TestRequireM2M_NormalUserToken_Forbidden(t *testing.T) {
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// ---------------------------------------------------------------------------
+// M2MIdentityFromContext - framework-agnostic accessor
+// ---------------------------------------------------------------------------
+
+func TestM2MIdentityFromContext_Present_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	want := M2MIdentity{
+		Subject:  "admin/3a09ac44-1faf-4e66-843c-5152b09b19dc",
+		ClientID: "66bac70fbea746daa760",
+	}
+	ctx := context.WithValue(context.Background(), m2mIdentityContextKey{}, want)
+
+	got, ok := M2MIdentityFromContext(ctx)
+
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
+func TestM2MIdentityFromContext_Absent_ReturnsZeroFalse(t *testing.T) {
+	t.Parallel()
+
+	got, ok := M2MIdentityFromContext(context.Background())
+
+	assert.False(t, ok)
+	assert.Equal(t, M2MIdentity{}, got)
+}
+
+func TestM2MIdentityFromContext_EmptySubject_TreatedAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	// A value with an empty Subject must be reported as absent (ok == false) so a
+	// caller that only checks ok never treats a half-populated identity as
+	// authenticated. RequireM2M never stores such a value (verify rejects an empty
+	// sub), so this only guards against manual/defensive construction.
+	ctx := context.WithValue(context.Background(), m2mIdentityContextKey{}, M2MIdentity{Subject: "", ClientID: "azp-only"})
+
+	_, ok := M2MIdentityFromContext(ctx)
+
+	assert.False(t, ok)
 }

--- a/auth/middleware/m2m_test.go
+++ b/auth/middleware/m2m_test.go
@@ -469,7 +469,8 @@ func TestM2MIdentityFromContext_EmptySubject_TreatedAsAbsent(t *testing.T) {
 	// sub), so this only guards against manual/defensive construction.
 	ctx := context.WithValue(context.Background(), m2mIdentityContextKey{}, M2MIdentity{Subject: "", ClientID: "azp-only"})
 
-	_, ok := M2MIdentityFromContext(ctx)
+	id, ok := M2MIdentityFromContext(ctx)
 
 	assert.False(t, ok)
+	assert.Equal(t, M2MIdentity{}, id, "an empty-subject identity must be reported as the zero value")
 }


### PR DESCRIPTION
## What

`RequireM2M` now stores the authenticated application identity on the request **Go `context.Context`** (via `c.SetContext`), in addition to the existing span attributes. Downstream code reads it through a single, framework-agnostic accessor:

```go
func M2MIdentityFromContext(ctx context.Context) (M2MIdentity, bool)
```

`M2MIdentity` carries `Subject` (the `sub` claim) and `ClientID` (the `azp` claim). The value is keyed by an unexported typed key (`m2mIdentityContextKey struct{}`) to avoid `context` string-key collisions.

## Why

A consumer (plugin-access-manager) registers a Huma operation via `humafiber`. The Huma handler receives a Go `context.Context` that humafiber derives from Fiber's `c.Context()` and resolves `Value(key)` against. The previous accessors exposed the identity **only** via Fiber Locals (`M2MSubjectFromContext` / `M2MClientIDFromContext`, keyed by `c.Locals`), which a Huma handler cannot cleanly reach.

Propagating the identity on the Go context lets **any** downstream — Huma handlers, gRPC, or fiber-native handlers via `c.Context()` — read it with one typed accessor. This is the same mechanism the added end-to-end test exercises through `app.Test`.

The identity is derived from `c.Context()` (the request Go ctx), **not** the tracing/span context, so the change adds only the identity value and does **not** alter span/tracing topology. Existing span attributes (`app.auth.m2m.subject` / `app.auth.m2m.client_id`) are preserved.

## Removed: the unused Fiber-Locals accessors

`M2MSubjectFromContext(c fiber.Ctx)` and `M2MClientIDFromContext(c fiber.Ctx)` (plus their two `c.Locals` writes and two string const keys) are removed. They were introduced in this same beta line (3.0.0-beta.x, PR #125) and have **no production consumers**, so replacing them with the single ctx-based API is clean and non-disruptive. A fiber-native caller still reads the identity via `M2MIdentityFromContext(c.Context())`. The only in-repo consumer was the test helper `newTestM2MApp`, migrated to the new API.

## Not touched

No change to verification logic (`verify`: RS256 pinning, issuer/expiry/type checks, fail-closed statuses). `middleware.go` / `middlewareGRPC.go` are untouched (they never referenced the removed symbols).

## Tests (TDD)

- End-to-end propagation via `app.Test`: a downstream handler reads `M2MIdentityFromContext(c.Context())` and echoes the identity into response headers; a valid application token yields the expected `Subject`/`ClientID` downstream.
- Unit tests for `M2MIdentityFromContext`: present round-trips; absent -> `(zero, false)`; empty-subject -> reported as absent (`ok == false`).
- All pre-existing gate tests remain green (missing token 401, non-application 403, valid 200, alg-confusion / none / expiry / missing-exp / issuer cases).

`go build ./...`, `go test -race ./...`, `gofmt -l`, `go vet ./...` all clean. Changed symbols are 100% covered (`RequireM2M` 100%, `M2MIdentityFromContext` 100%).

semantic-release will cut the next beta on merge to develop.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>