### PR TITLE
feat(middleware): add fail-closed AUTH_REQUIRED option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ PLUGIN_AUTH_ENABLED=true
 # permissions by product (matching product-prefixed resources). Defaults to
 # false, preserving the previous behavior of sending no product for M2M.
 AUTH_M2M_PRODUCT_FORWARD_ENABLED=false
+
+# Optional. When "true", the middleware fails closed: if auth is disabled
+# (PLUGIN_AUTH_ENABLED=false) or misconfigured (empty PLUGIN_AUTH_ADDRESS),
+# every protected route refuses to serve (HTTP 503 / gRPC Unavailable) instead
+# of passing through unauthenticated. Defaults to false, preserving the prior
+# fail-open behavior. Set it in security-sensitive deployments so a
+# missing/typo'd address cannot silently downgrade a protected service to open.
+AUTH_REQUIRED=false
 ```
 
 ### 2. Create a new instance of the middleware:

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -39,6 +39,16 @@ type AuthClient struct {
 	// Gating it by env keeps deploy != release: flipping the flag activates M2M
 	// product isolation without a code change in consumers.
 	ForwardM2MProduct bool
+
+	// Required, when true, makes the middleware fail closed: if auth is disabled
+	// or misconfigured (!Enabled || Address == ""), every protected route refuses
+	// to serve (HTTP 503 / gRPC Unavailable) instead of passing through with
+	// c.Next()/handler(). It is read once from AUTH_REQUIRED at construction; the
+	// default (false) preserves the prior fail-open pass-through behavior exactly.
+	// This inverts the default posture only for deployments that opt in, so a
+	// missing/typo'd address can no longer silently downgrade a protected service
+	// to fully open.
+	Required bool
 }
 
 type AuthResponse struct {
@@ -175,13 +185,20 @@ func NewAuthClient(address string, enabled bool, logger *log.Logger) *AuthClient
 	}
 
 	forwardM2MProduct := os.Getenv("AUTH_M2M_PRODUCT_FORWARD_ENABLED") == "true"
+	required := os.Getenv("AUTH_REQUIRED") == "true"
 
 	if !enabled || address == "" {
+		if required {
+			logErrorf(context.Background(), l,
+				"AUTH_REQUIRED is set but auth is disabled or address is empty: middleware will fail closed (refuse to serve)")
+		}
+
 		return &AuthClient{
 			Address:           address,
 			Enabled:           enabled,
 			Logger:            l,
 			ForwardM2MProduct: forwardM2MProduct,
+			Required:          required,
 		}
 	}
 
@@ -194,21 +211,21 @@ func NewAuthClient(address string, enabled bool, logger *log.Logger) *AuthClient
 	if err != nil {
 		logErrorf(context.Background(), l, failedToConnectMsg, err)
 
-		return &AuthClient{Address: address, Enabled: enabled, Logger: l, ForwardM2MProduct: forwardM2MProduct}
+		return &AuthClient{Address: address, Enabled: enabled, Logger: l, ForwardM2MProduct: forwardM2MProduct, Required: required}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		logErrorf(context.Background(), l, failedToConnectMsg, resp.Status)
 
-		return &AuthClient{Address: address, Enabled: enabled, Logger: l, ForwardM2MProduct: forwardM2MProduct}
+		return &AuthClient{Address: address, Enabled: enabled, Logger: l, ForwardM2MProduct: forwardM2MProduct, Required: required}
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logErrorf(context.Background(), l, "Failed to read response body: %v", err)
 
-		return &AuthClient{Address: address, Enabled: enabled, Logger: l, ForwardM2MProduct: forwardM2MProduct}
+		return &AuthClient{Address: address, Enabled: enabled, Logger: l, ForwardM2MProduct: forwardM2MProduct, Required: required}
 	}
 
 	if string(body) == "healthy" {
@@ -222,7 +239,24 @@ func NewAuthClient(address string, enabled bool, logger *log.Logger) *AuthClient
 		Enabled:           enabled,
 		Logger:            l,
 		ForwardM2MProduct: forwardM2MProduct,
+		Required:          required,
 	}
+}
+
+// canAuthorize reports whether the client is able to perform an authorization
+// check: non-nil, Enabled, and holding an Address. When it returns false the
+// caller passes the request through (default, fail open) unless Required is set.
+// A nil receiver is safe and reports false, so a nil client is never usable.
+func (auth *AuthClient) canAuthorize() bool {
+	return auth != nil && auth.Enabled && auth.Address != ""
+}
+
+// mustRefuse reports whether a client that cannot authorize must fail closed
+// (refuse to serve) instead of passing the request through. It is true only when
+// the client is non-nil, opted in via Required (AUTH_REQUIRED), and cannot
+// authorize (disabled or no address). This is the fail-closed switch from #107.
+func (auth *AuthClient) mustRefuse() bool {
+	return auth != nil && auth.Required && !auth.canAuthorize()
 }
 
 // Authorize is a middleware function for the Fiber framework that checks if a user is authorized to perform a specific action on a resource.
@@ -235,7 +269,13 @@ func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handle
 
 		_, tracer, reqID, _ := observability.NewTrackingFromContext(ctx)
 
-		if !auth.Enabled || auth.Address == "" {
+		if auth.mustRefuse() {
+			// AUTH_REQUIRED opted in but auth is disabled/misconfigured: refuse to
+			// serve (fail closed) instead of silently passing the request through.
+			return c.Status(http.StatusServiceUnavailable).SendString("Service Unavailable")
+		}
+
+		if !auth.canAuthorize() {
 			return c.Next()
 		}
 

--- a/auth/middleware/middlewareGRPC.go
+++ b/auth/middleware/middlewareGRPC.go
@@ -52,7 +52,13 @@ type PolicyConfig struct {
 //     AUTH_M2M_PRODUCT_FORWARD_ENABLED is set), mirroring the request body.
 func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if auth == nil || !auth.Enabled || auth.Address == "" {
+		if auth.mustRefuse() {
+			// AUTH_REQUIRED opted in but auth is disabled/misconfigured: refuse the
+			// RPC (fail closed) instead of silently passing it through.
+			return nil, status.Error(codes.Unavailable, "service unavailable")
+		}
+
+		if !auth.canAuthorize() {
 			return handler(ctx, req)
 		}
 
@@ -106,28 +112,39 @@ func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServer
 		}
 
 		// Propagate tenant claims if multi-tenant mode is enabled
-		if os.Getenv("MULTI_TENANT_ENABLED") == "true" {
-			tenantID, tenantSlug, tOwner, _ := extractTenantClaims(token)
-			md, _ := metadata.FromIncomingContext(ctx)
-			md = md.Copy()
-
-			if tenantID != "" {
-				md.Set("md-tenant-id", tenantID)
-			}
-
-			if tenantSlug != "" {
-				md.Set("md-tenant-slug", tenantSlug)
-			}
-
-			if tOwner != "" {
-				md.Set("md-tenant-owner", tOwner)
-			}
-
-			ctx = metadata.NewIncomingContext(ctx, md)
-		}
+		ctx, _ = tenantContext(ctx, token)
 
 		return handler(ctx, req)
 	}
+}
+
+// tenantContext returns ctx augmented with tenant metadata (md-tenant-id/slug/owner)
+// extracted from the token when MULTI_TENANT_ENABLED is set, along with whether it
+// added anything. When multi-tenant mode is off it returns ctx unchanged and false.
+// Shared by the unary and stream interceptors to avoid duplicating the propagation
+// logic; the bool lets the stream interceptor decide whether to wrap its stream.
+func tenantContext(ctx context.Context, token string) (context.Context, bool) {
+	if os.Getenv("MULTI_TENANT_ENABLED") != "true" {
+		return ctx, false
+	}
+
+	tenantID, tenantSlug, tOwner, _ := extractTenantClaims(token)
+	md, _ := metadata.FromIncomingContext(ctx)
+	md = md.Copy()
+
+	if tenantID != "" {
+		md.Set("md-tenant-id", tenantID)
+	}
+
+	if tenantSlug != "" {
+		md.Set("md-tenant-slug", tenantSlug)
+	}
+
+	if tOwner != "" {
+		md.Set("md-tenant-owner", tOwner)
+	}
+
+	return metadata.NewIncomingContext(ctx, md), true
 }
 
 // extractTokenFromMD returns the bearer token from incoming metadata "authorization".
@@ -274,7 +291,13 @@ func extractTenantClaims(tokenString string) (tenantID, tenantSlug, owner string
 // - Propagates tenant claims when MULTI_TENANT_ENABLED=true.
 func NewGRPCAuthStreamPolicy(auth *AuthClient, cfg PolicyConfig) grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		if auth == nil || !auth.Enabled || auth.Address == "" {
+		if auth.mustRefuse() {
+			// AUTH_REQUIRED opted in but auth is disabled/misconfigured: refuse the
+			// stream (fail closed) instead of silently passing it through.
+			return status.Error(codes.Unavailable, "service unavailable")
+		}
+
+		if !auth.canAuthorize() {
 			return handler(srv, ss)
 		}
 
@@ -314,25 +337,8 @@ func NewGRPCAuthStreamPolicy(auth *AuthClient, cfg PolicyConfig) grpc.StreamServ
 		}
 
 		// Propagate tenant claims if multi-tenant mode is enabled
-		if os.Getenv("MULTI_TENANT_ENABLED") == "true" {
-			tenantID, tenantSlug, tOwner, _ := extractTenantClaims(token)
-			md, _ := metadata.FromIncomingContext(ctx)
-			md = md.Copy()
-
-			if tenantID != "" {
-				md.Set("md-tenant-id", tenantID)
-			}
-
-			if tenantSlug != "" {
-				md.Set("md-tenant-slug", tenantSlug)
-			}
-
-			if tOwner != "" {
-				md.Set("md-tenant-owner", tOwner)
-			}
-
-			ctx = metadata.NewIncomingContext(ctx, md)
-			ss = &wrappedServerStream{ServerStream: ss, ctx: ctx}
+		if tenantCtx, wrapped := tenantContext(ctx, token); wrapped {
+			ss = &wrappedServerStream{ServerStream: ss, ctx: tenantCtx}
 		}
 
 		return handler(srv, ss)

--- a/auth/middleware/middlewareGRPC_test.go
+++ b/auth/middleware/middlewareGRPC_test.go
@@ -487,6 +487,50 @@ func TestNewGRPCAuthUnaryPolicy(t *testing.T) {
 		assert.True(t, called)
 	})
 
+	t.Run("required_and_disabled_refuses_with_unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		handler := func(_ context.Context, _ any) (any, error) {
+			called = true
+			return "ok", nil
+		}
+
+		auth := &AuthClient{Address: "http://localhost:9999", Enabled: false, Required: true}
+		interceptor := NewGRPCAuthUnaryPolicy(auth, PolicyConfig{})
+
+		resp, err := interceptor(context.Background(), "req", dummyInfo, handler)
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.False(t, called)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
+	})
+
+	t.Run("required_and_empty_address_refuses_with_unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+		handler := func(_ context.Context, _ any) (any, error) {
+			called = true
+			return "ok", nil
+		}
+
+		auth := &AuthClient{Address: "", Enabled: true, Required: true}
+		interceptor := NewGRPCAuthUnaryPolicy(auth, PolicyConfig{})
+
+		resp, err := interceptor(context.Background(), "req", dummyInfo, handler)
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.False(t, called)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
+	})
+
 	t.Run("missing_token_returns_unauthenticated", func(t *testing.T) {
 		t.Parallel()
 
@@ -1045,6 +1089,30 @@ func TestNewGRPCAuthStreamPolicy(t *testing.T) {
 		err := interceptor(nil, ss, dummyInfo, handler)
 		require.NoError(t, err)
 		assert.True(t, called)
+	})
+
+	t.Run("required_and_disabled_refuses_with_unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		called := false
+
+		handler := func(_ any, _ grpc.ServerStream) error {
+			called = true
+			return nil
+		}
+
+		auth := &AuthClient{Address: "http://localhost:9999", Enabled: false, Required: true}
+		interceptor := NewGRPCAuthStreamPolicy(auth, PolicyConfig{})
+
+		ss := &fakeServerStream{ctx: context.Background()}
+
+		err := interceptor(nil, ss, dummyInfo, handler)
+		require.Error(t, err)
+		assert.False(t, called)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unavailable, st.Code())
 	})
 
 	t.Run("missing_token_returns_unauthenticated", func(t *testing.T) {

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	observability "github.com/LerianStudio/lib-observability/v2"
 	"github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/gofiber/fiber/v3"
 	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -692,6 +694,115 @@ func TestNewAuthClient_ReadsForwardM2MProductFlag(t *testing.T) {
 
 		client := NewAuthClient("", false, &logger)
 		assert.False(t, client.ForwardM2MProduct)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NewAuthClient - Required (AUTH_REQUIRED) flag
+// ---------------------------------------------------------------------------
+
+func TestNewAuthClient_ReadsRequiredFlag(t *testing.T) {
+	// Cannot use t.Parallel(): subtests use t.Setenv which modifies process env.
+	// enabled=false / empty address returns early without any network call, so the
+	// flag wiring is exercised in isolation.
+	logger := log.Logger(&testLogger{})
+
+	t.Run("flag_true_enables_required", func(t *testing.T) {
+		t.Setenv("AUTH_REQUIRED", "true")
+
+		client := NewAuthClient("", false, &logger)
+		assert.True(t, client.Required)
+	})
+
+	t.Run("flag_absent_defaults_false", func(t *testing.T) {
+		t.Setenv("AUTH_REQUIRED", "")
+
+		client := NewAuthClient("", false, &logger)
+		assert.False(t, client.Required)
+	})
+
+	t.Run("flag_non_true_value_is_false", func(t *testing.T) {
+		t.Setenv("AUTH_REQUIRED", "1")
+
+		client := NewAuthClient("", false, &logger)
+		assert.False(t, client.Required)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Authorize - fail-closed (AUTH_REQUIRED) posture
+// ---------------------------------------------------------------------------
+
+func TestAuthorize_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	const reached = "reached handler"
+
+	newApp := func(auth *AuthClient) *fiber.App {
+		app := fiber.New()
+		app.Get("/x", auth.Authorize("product", "resource", "get"), func(c fiber.Ctx) error {
+			return c.SendString(reached)
+		})
+
+		return app
+	}
+
+	t.Run("required_and_disabled_refuses_with_503", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &AuthClient{Enabled: false, Required: true, Logger: &testLogger{}}
+
+		resp, err := newApp(auth).Test(httptest.NewRequest(http.MethodGet, "/x", nil))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+
+	t.Run("required_and_empty_address_refuses_with_503", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &AuthClient{Address: "", Enabled: true, Required: true, Logger: &testLogger{}}
+
+		resp, err := newApp(auth).Test(httptest.NewRequest(http.MethodGet, "/x", nil))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+
+	t.Run("not_required_and_disabled_passes_through", func(t *testing.T) {
+		t.Parallel()
+
+		auth := &AuthClient{Enabled: false, Required: false, Logger: &testLogger{}}
+
+		resp, err := newApp(auth).Test(httptest.NewRequest(http.MethodGet, "/x", nil))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, reached, string(body))
+	})
+
+	t.Run("required_and_enabled_authorizes_normally", func(t *testing.T) {
+		t.Parallel()
+
+		server := mockAuthServer(t, true, http.StatusOK)
+		defer server.Close()
+
+		auth := &AuthClient{Address: server.URL, Enabled: true, Required: true, Logger: &testLogger{}}
+
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("Authorization", "Bearer "+createTestJWT(jwt.MapClaims{
+			"type":  "normal-user",
+			"owner": "org1",
+			"sub":   "user1",
+		}))
+
+		resp, err := newApp(auth).Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, reached, string(body))
 	})
 }
 


### PR DESCRIPTION
## What

Adds an opt-in **fail-closed** switch to the auth middleware so a
disabled/misconfigured client refuses to serve instead of silently passing every
request through unauthenticated.

- New `AuthClient.Required bool` field, read once from the `AUTH_REQUIRED` env var
  at construction (mirrors the existing `AUTH_M2M_PRODUCT_FORWARD_ENABLED` wiring).
- When `Required == true` **and** auth cannot authorize (`!Enabled || Address == ""`),
  every protected route refuses to serve:
  - Fiber `Authorize` → **HTTP 503 Service Unavailable**
  - gRPC unary & stream interceptors → **`codes.Unavailable`**
- A loud error is logged at construction when `AUTH_REQUIRED` is set but auth is
  disabled/blank, so the misconfiguration is visible immediately rather than at
  first request.
- Default `Required == false` preserves the prior pass-through behavior **exactly**.

## Why

Per #107, the middleware fails **open**: `if !auth.Enabled || auth.Address == ""`
returns `c.Next()` (and the gRPC equivalents pass through). One missing/typo'd env
var silently downgrades a protected service to fully open, with no error, no boot
failure. Downstream (midaz) compensates with N hand-rolled per-service boot gates
that drift independently; the fail-closed posture belongs upstream in one place.

## Design decision: handler-level refusal, not a constructor error

The issue suggested "an error from the constructor / a hard 503 from the handler."
I chose the **503 / `codes.Unavailable` at the handler**, deliberately:

- `NewAuthClient` currently returns `*AuthClient` with **no error**. Retrofitting a
  `(*AuthClient, error)` signature is a breaking API change to every call site
  (README examples and consumers call it positionally) — which directly contradicts
  the "opt-in, backward-compatible" requirement. `NewM2MAuthenticator` returning an
  error is not a precedent to match here; it was *born* with that signature.
- Handler-level refusal is genuinely fail-closed: with `Required=true` and a
  misconfig, no route ever serves unauthenticated — it returns 503 on every request
  (loud, not silent). The added boot-time error log gives operators the deploy-time
  signal without a signature break.

## Scope note

`NewGRPCAuthUnaryPolicy` was already at the repo's cognitive-complexity ceiling on
`develop`. To add the fail-closed branch without tripping the linter or resorting to
a `//nolint`, the tenant-claim propagation block that was **duplicated verbatim** in
both gRPC interceptors is extracted into a shared `tenantContext` helper. Existing
tenant-propagation tests cover the extraction (no behavior change).

## Tests

Added, all passing (full package: 124 tests green; `golangci-lint run ./...` clean):

- `TestNewAuthClient_ReadsRequiredFlag` — `AUTH_REQUIRED` env → `Required` field
  (true / absent / non-`true`).
- `TestAuthorize_FailClosed` (Fiber, via `app.Test`): required+disabled → 503;
  required+blank-address → 503; **not-required+disabled → passes through (unchanged)**;
  required+enabled → normal authorize flow.
- `TestNewGRPCAuthUnaryPolicy` / `TestNewGRPCAuthStreamPolicy`: required+disabled and
  required+blank-address → `codes.Unavailable`, handler not invoked.

Closes #107

https://claude.ai/code/session_01RcQLK4qK1kbpvXWjuAR3Xh
