### PR TITLE
chore(deps): point to stable observability v2.0.0 and commons v6.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 )
 
 require (
-	github.com/LerianStudio/lib-commons/v6 v6.0.0-beta.2
-	github.com/LerianStudio/lib-observability/v2 v2.0.0-beta.1
+	github.com/LerianStudio/lib-commons/v6 v6.0.0
+	github.com/LerianStudio/lib-observability/v2 v2.0.0
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/bxcodec/dbresolver/v2 v2.2.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/LerianStudio/lib-commons/v6 v6.0.0-beta.2 h1:UwSvTUe3jDclz2M2huMuYIqVzbJ+WccMKON9rPda+jA=
-github.com/LerianStudio/lib-commons/v6 v6.0.0-beta.2/go.mod h1:wJzcspXD+S810PJUJn8SfFXIQgfy0OVFUeEA7QSREbg=
-github.com/LerianStudio/lib-observability/v2 v2.0.0-beta.1 h1:jqeROYaFDqdT0d8Wqv0GlbdOkMwvWiMxFKI6H7gGsR8=
-github.com/LerianStudio/lib-observability/v2 v2.0.0-beta.1/go.mod h1:gcpmb8FoTsuxUHVgW3sY8s2Pu558T4eDdboEnEowBrI=
+github.com/LerianStudio/lib-commons/v6 v6.0.0 h1:XDKyCKdb2h3l0MBwQQNBRuCsiSTjafJfgp/QLMAEzd0=
+github.com/LerianStudio/lib-commons/v6 v6.0.0/go.mod h1:bOPZG4oO2xoSE307JJyXKyhmBo7EyQ5g8DEw5fI/ZEg=
+github.com/LerianStudio/lib-observability/v2 v2.0.0 h1:B13t2TlLvu9awqMsnJ6d0RWeftUlf1ROBxLB3okSn6c=
+github.com/LerianStudio/lib-observability/v2 v2.0.0/go.mod h1:MuHQdrM8twiwewkwSO1TX6/931mI9oTM0NCIVjumPhQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=


### PR DESCRIPTION
## Description
Pins `lib-observability/v2` and `lib-commons/v6` to their **stable** releases (`v2.0.0` / `v6.0.0`), were `v2.0.0-beta.1` / `v6.0.0-beta.2`. Only `go.mod`/`go.sum`; no code changes. `go build ./...` passes.

## Type of Change
- [x] `chore` / `build`: dependency version pins

## Breaking Changes
None.

## Related
Part of the beta→stable rollout (observability → commons → auth/license). Precedes the v3 release PR.
