### PR TITLE
feat(middleware): forward client IP to /v1/authorize for IP allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,22 @@ The `clientIp` field is optional. On the Fiber path it is set automatically to `
 On the Fiber path, `Authorize` automatically sends `clientIp = c.IP()` to `POST /v1/authorize`, enabling the access manager to enforce a per-tenant IP allowlist downstream.
 
 * **No code change needed.** The public `Authorize(sub, resource, action)` signature is unchanged. Consuming services get this behavior by upgrading the library — bump the version, nothing else.
-* **Configure trusted proxies.** For `c.IP()` to report the real client IP behind a proxy or ingress, the consuming service must configure Fiber's trusted proxies (its own `TRUSTED_PROXIES` / `TrustProxy` setup). Without it, `c.IP()` is the socket peer (the proxy), not the caller.
+* **Configure trusted proxies (Fiber v3).** For `c.IP()` to report the real client IP behind a proxy or ingress, the consuming service must configure Fiber v3's trusted-proxy settings on its `fiber.New(fiber.Config{...})`:
+  * `TrustProxy: true` — enable proxy-header trust (Fiber v3 renamed the v2 `EnableTrustedProxyCheck`).
+  * `TrustProxyConfig: fiber.TrustProxyConfig{Proxies: []string{"10.0.0.0/8", "<ingress-cidr>"}}` — the exact set of upstream proxy IPs/CIDRs allowed to set the forwarded header. Never leave this empty while trusting the header, or any caller can spoof its IP.
+  * `ProxyHeader: fiber.HeaderXForwardedFor` — the header `c.IP()` reads the client IP from.
+  * `EnableIPValidation: true` — validates that the value is a well-formed IP, so `c.IP()` cannot return a spoofable raw `X-Forwarded-For` string.
+
+  Without this, `c.IP()` is the socket peer (the proxy), not the caller; misconfigured (trusting the header without pinning `Proxies`), it is attacker-controlled. Example:
+
+  ```go
+  f := fiber.New(fiber.Config{
+      TrustProxy:         true,
+      TrustProxyConfig:   fiber.TrustProxyConfig{Proxies: []string{"10.0.0.0/8"}},
+      ProxyHeader:        fiber.HeaderXForwardedFor,
+      EnableIPValidation: true,
+  })
+  ```
 * **gRPC is not IP-enforced yet.** The gRPC interceptors do not forward a client IP in this version, so gRPC-authorized calls skip IP allowlist enforcement. Peer/metadata IP extraction is a planned follow-up.
 * **Cache is IP-scoped.** When `AUTH_CACHE_TTL > 0`, the decision cache key includes `clientIp`, so a decision cached for one IP is never reused for another. IP-dependent decisions stay correct under caching.
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ AUTH_REQUIRED=false
 # (Go duration). Defaults to 30s (behavior-neutral). It also caps the retry budget.
 AUTH_TIMEOUT=30s
 # AUTH_CACHE_TTL enables a short-lived decision cache when > 0, keyed by
-# (subject, resource, action, product) — never the token. Empty/0 disables it
-# (default). Security tradeoff: a permission revocation takes up to the TTL to
-# propagate, so keep it small (5–15s). It sheds load and, with the breaker,
-# survives brief authz outages by serving fresh positive decisions.
+# (subject, resource, action, product, clientIp) — never the token. Empty/0
+# disables it (default). Security tradeoff: a permission revocation takes up to
+# the TTL to propagate, so keep it small (5–15s). It sheds load and, with the
+# breaker, survives brief authz outages by serving fresh positive decisions.
+# The clientIp is part of the key so an IP-dependent decision cached for one
+# caller is never reused for another (see "Client IP forwarding" below).
 AUTH_CACHE_TTL=
 # AUTH_BREAKER_ENABLED opens a circuit breaker after sustained authz failures.
 # While open it serves ONLY a fresh positive cache hit and otherwise denies;
@@ -114,6 +116,7 @@ The `Authorize` function:
 
 * Receives the `sub` (user), `resource` (resource), and `action` (desired action).
 * Sends a POST request to the authorization service.
+* On the Fiber path, forwards the caller's client IP (`c.IP()`) as the optional `clientIp` field (see [Client IP forwarding](#-client-ip-forwarding)).
 * Checks if the response indicates that the user is authorized.
 * Allows the normal application flow or returns a 403 (Forbidden) error.
 
@@ -127,9 +130,21 @@ Authorization: Bearer your_token_here
 {
     "sub":      "lerian/userId",
     "resource": "resourceName",
-    "action":   "get"
+    "action":   "get",
+    "clientIp": "203.0.113.45"
 }
 ```
+
+The `clientIp` field is optional. On the Fiber path it is set automatically to `c.IP()`; the authorization service uses it to enforce the per-tenant IP allowlist.
+
+## 🌐 Client IP forwarding
+
+On the Fiber path, `Authorize` automatically sends `clientIp = c.IP()` to `POST /v1/authorize`, enabling the access manager to enforce a per-tenant IP allowlist downstream.
+
+* **No code change needed.** The public `Authorize(sub, resource, action)` signature is unchanged. Consuming services get this behavior by upgrading the library — bump the version, nothing else.
+* **Configure trusted proxies.** For `c.IP()` to report the real client IP behind a proxy or ingress, the consuming service must configure Fiber's trusted proxies (its own `TRUSTED_PROXIES` / `TrustProxy` setup). Without it, `c.IP()` is the socket peer (the proxy), not the caller.
+* **gRPC is not IP-enforced yet.** The gRPC interceptors do not forward a client IP in this version, so gRPC-authorized calls skip IP allowlist enforcement. Peer/metadata IP extraction is a planned follow-up.
+* **Cache is IP-scoped.** When `AUTH_CACHE_TTL > 0`, the decision cache key includes `clientIp`, so a decision cached for one IP is never reused for another. IP-dependent decisions stay correct under caching.
 
 ## 📡 Expected Authorization Service Response
 
@@ -174,6 +189,7 @@ Notes:
 - Keys in `MethodPolicies` must be full method names in the form `/package.Service/Method`.
 - When `SubResolver` returns an empty string, the subject is derived from token claims.
  - If you already use multiple interceptors, prefer `grpc.ChainUnaryInterceptor(...)` and include the auth interceptor alongside telemetry/logging.
+ - The interceptors do not forward a client IP in this version, so gRPC-authorized calls are not IP-allowlist enforced yet. See [Client IP forwarding](#-client-ip-forwarding).
 
 ## 🚧 Error Handling
 

--- a/auth/middleware/decisioncache.go
+++ b/auth/middleware/decisioncache.go
@@ -28,6 +28,13 @@ type cacheKey struct {
 	resource string
 	action   string
 	product  string
+	// clientIP scopes the decision to the source IP it was made for. The
+	// /v1/authorize decision is IP-dependent (tenant IP-allowlist), so omitting it
+	// would let an "authorized" decision cached for an allowed IP be served to a
+	// request from a blocked IP with the same {sub,resource,action,product} —
+	// bypassing the allowlist. Empty (gRPC / no forwarded IP) keys as "", unchanged
+	// from before. This trades a little hit rate for correctness, which is required.
+	clientIP string
 }
 
 // cacheEntry is a cached authorization decision with its expiry.
@@ -65,7 +72,7 @@ func newDecisionCache(ttl time.Duration) *decisionCache {
 // distinct field boundaries cannot collide (e.g. {"a","b"} vs {"ab",""}).
 func (c *decisionCache) shardFor(k cacheKey) *cacheShard {
 	h := fnv.New32a()
-	_, _ = h.Write([]byte(k.sub + "\x00" + k.resource + "\x00" + k.action + "\x00" + k.product))
+	_, _ = h.Write([]byte(k.sub + "\x00" + k.resource + "\x00" + k.action + "\x00" + k.product + "\x00" + k.clientIP))
 
 	return c.shards[h.Sum32()%decisionCacheShards]
 }

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -333,7 +333,13 @@ func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handle
 			return c.Status(http.StatusUnauthorized).SendString("Missing Token")
 		}
 
-		if authorized, statusCode, err := auth.checkAuthorization(ctx, product, resource, action, accessToken); err != nil {
+		// Capture the caller IP resolved by Fiber (honoring the configured trusted
+		// proxy / ProxyHeader chain) and forward it so the auth service can apply
+		// IP-based policy. It is optional end-to-end: an empty value is omitted from
+		// the request body (see checkAuthorization).
+		clientIP := c.IP()
+
+		if authorized, statusCode, err := auth.checkAuthorization(ctx, product, resource, action, accessToken, clientIP); err != nil {
 			var commonsErr commons.Response
 			if errors.As(err, &commonsErr) {
 				span.End()
@@ -428,7 +434,13 @@ func shouldForwardProduct(userType, product string, forwardM2MProduct bool) bool
 	return userType == normalUser || (userType == application && forwardM2MProduct)
 }
 
-func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resource, action, accessToken string) (bool, int, error) {
+// checkAuthorization builds and sends the authorization request to the auth
+// service. clientIP is the resolved caller IP forwarded as the OPTIONAL
+// "clientIp" body field; when empty (e.g. gRPC callers, which do not extract a
+// peer IP in v1) the field is omitted so the wire body stays byte-identical to
+// the pre-IP behavior for every deployed access-manager. The auth service
+// interprets the IP; this layer never parses or validates it.
+func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resource, action, accessToken, clientIP string) (bool, int, error) {
 	_, tracer, reqID, _ := observability.NewTrackingFromContext(ctx)
 
 	ctx, span := tracer.Start(ctx, "lib_auth.check_authorization")
@@ -466,6 +478,12 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 		requestBody["product"] = product
 	}
 
+	// clientIp is optional: include it only when a caller IP was resolved, so an
+	// empty IP leaves the request body byte-identical to the pre-IP behavior.
+	if clientIP != "" {
+		requestBody["clientIp"] = clientIP
+	}
+
 	err = tracing.SetSpanAttributesFromValue(span, "app.request.payload", requestBody, nil)
 	if err != nil {
 		tracing.HandleSpanError(span, "Failed to convert request body to JSON string", err)
@@ -484,8 +502,9 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 
 	// Cache key = exactly the authz request inputs (never the raw token). product is
 	// the value actually forwarded ("" when not forwarded), so the key matches the
-	// decision the authz service made.
-	key := cacheKey{sub: sub, resource: resource, action: action, product: requestBody["product"]}
+	// decision the authz service made. clientIP is in the key because the decision is
+	// IP-dependent (tenant IP-allowlist): a cross-IP cache hit would bypass it.
+	key := cacheKey{sub: sub, resource: resource, action: action, product: requestBody["product"], clientIP: clientIP}
 
 	// A fresh cache hit (positive OR negative) short-circuits before the breaker, so
 	// the breaker only ever runs on a miss — its open state then denies (never

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -59,9 +59,11 @@ type AuthClient struct {
 	timeout time.Duration
 
 	// cache, when non-nil, memoizes authorization decisions for a short TTL keyed by
-	// (sub, resource, action, product) — NEVER the raw token. Enabled by
-	// AUTH_CACHE_TTL > 0 (opt-in; nil = no caching, prior behavior). It trades a
-	// bounded revocation-propagation lag (= TTL) for load shedding and outage
+	// (sub, resource, action, product, clientIp) — NEVER the access token. clientIp
+	// is part of the key because decisions are IP-dependent (tenant IP-allowlist), so
+	// a cross-IP cache hit would bypass the allowlist; do NOT drop it from the key.
+	// Enabled by AUTH_CACHE_TTL > 0 (opt-in; nil = no caching, prior behavior). It
+	// trades a bounded revocation-propagation lag (= TTL) for load shedding and outage
 	// resilience.
 	cache *decisionCache
 

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -478,8 +478,8 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 		requestBody["product"] = product
 	}
 
-	// clientIp is optional: include it only when a caller IP was resolved, so an
-	// empty IP leaves the request body byte-identical to the pre-IP behavior.
+	// clientIp is optional: the field is omitted when empty, so callers that don't
+	// resolve a client IP send the same request body (no clientIp key) as before.
 	if clientIP != "" {
 		requestBody["clientIp"] = clientIP
 	}

--- a/auth/middleware/middlewareGRPC.go
+++ b/auth/middleware/middlewareGRPC.go
@@ -102,7 +102,9 @@ func NewGRPCAuthUnaryPolicy(auth *AuthClient, cfg PolicyConfig) grpc.UnaryServer
 			tracing.HandleSpanError(span, "failed to set span payload", err)
 		}
 
-		authorized, httpStatus, err := auth.checkAuthorization(ctx, product, pol.Resource, pol.Action, token)
+		// clientIP is empty for gRPC: peer/metadata IP extraction is the approved
+		// follow-up epic, out of v1 scope, so no clientIp is forwarded here.
+		authorized, httpStatus, err := auth.checkAuthorization(ctx, product, pol.Resource, pol.Action, token, "")
 		if err != nil {
 			return nil, grpcErrorFromHTTP(httpStatus)
 		}
@@ -327,7 +329,9 @@ func NewGRPCAuthStreamPolicy(auth *AuthClient, cfg PolicyConfig) grpc.StreamServ
 			}
 		}
 
-		authorized, httpStatus, err := auth.checkAuthorization(ctx, product, pol.Resource, pol.Action, token)
+		// clientIP is empty for gRPC: peer/metadata IP extraction is the approved
+		// follow-up epic, out of v1 scope, so no clientIp is forwarded here.
+		authorized, httpStatus, err := auth.checkAuthorization(ctx, product, pol.Resource, pol.Action, token, "")
 		if err != nil {
 			return grpcErrorFromHTTP(httpStatus)
 		}

--- a/auth/middleware/middlewareGRPC_test.go
+++ b/auth/middleware/middlewareGRPC_test.go
@@ -1012,6 +1012,61 @@ func TestNewGRPCAuthUnaryPolicy_NoClientIP(t *testing.T) {
 	assert.False(t, hasClientIP, "gRPC path must not send clientIp")
 }
 
+// TestNewGRPCAuthStreamPolicy_NoClientIP asserts the gRPC stream path never sends a
+// clientIp field: peer/metadata IP extraction for gRPC is an approved follow-up
+// epic, out of v1 scope, so checkAuthorization is called with an empty clientIP.
+func TestNewGRPCAuthStreamPolicy_NoClientIP(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Errorf("mock server: failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(AuthResponse{Authorized: true}); err != nil {
+			t.Errorf("mock server: failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	})
+
+	defaultPol := Policy{Resource: "res", Action: "read"}
+	interceptor := NewGRPCAuthStreamPolicy(auth, PolicyConfig{DefaultPolicy: &defaultPol})
+
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("authorization", "Bearer "+token),
+	)
+
+	called := false
+	handler := func(_ any, _ grpc.ServerStream) error {
+		called = true
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{FullMethod: "/pkg.Service/StreamThing"}
+	ss := &fakeServerStream{ctx: ctx}
+
+	err := interceptor(nil, ss, info, handler)
+	require.NoError(t, err)
+	assert.True(t, called)
+
+	_, hasClientIP := capturedBody["clientIp"]
+	assert.False(t, hasClientIP, "gRPC stream path must not send clientIp")
+}
+
 func TestNewGRPCAuthUnaryPolicy_ApplicationSubject_ForwardM2MProductEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/auth/middleware/middlewareGRPC_test.go
+++ b/auth/middleware/middlewareGRPC_test.go
@@ -963,6 +963,55 @@ func TestNewGRPCAuthUnaryPolicy_ApplicationSubject(t *testing.T) {
 	assert.False(t, hasProduct)
 }
 
+// TestNewGRPCAuthUnaryPolicy_NoClientIP asserts the gRPC unary path never sends a
+// clientIp field: peer/metadata IP extraction for gRPC is an approved follow-up
+// epic, out of v1 scope, so checkAuthorization is called with an empty clientIP.
+func TestNewGRPCAuthUnaryPolicy_NoClientIP(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Errorf("mock server: failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(AuthResponse{Authorized: true}); err != nil {
+			t.Errorf("mock server: failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	})
+
+	defaultPol := Policy{Resource: "res", Action: "read"}
+	interceptor := NewGRPCAuthUnaryPolicy(auth, PolicyConfig{DefaultPolicy: &defaultPol})
+
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("authorization", "Bearer "+token),
+	)
+
+	handler := func(_ context.Context, _ any) (any, error) { return "ok", nil }
+	info := &grpc.UnaryServerInfo{FullMethod: "/pkg.Service/DoThing"}
+
+	resp, err := interceptor(ctx, "req", info, handler)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+
+	_, hasClientIP := capturedBody["clientIp"]
+	assert.False(t, hasClientIP, "gRPC path must not send clientIp")
+}
+
 func TestNewGRPCAuthUnaryPolicy_ApplicationSubject_ForwardM2MProductEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/auth/middleware/middlewareGRPC_test.go
+++ b/auth/middleware/middlewareGRPC_test.go
@@ -1008,6 +1008,7 @@ func TestNewGRPCAuthUnaryPolicy_NoClientIP(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok", resp)
 
+	require.NotNil(t, capturedBody, "authorization request was not captured")
 	_, hasClientIP := capturedBody["clientIp"]
 	assert.False(t, hasClientIP, "gRPC path must not send clientIp")
 }
@@ -1063,6 +1064,7 @@ func TestNewGRPCAuthStreamPolicy_NoClientIP(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, called)
 
+	require.NotNil(t, capturedBody, "authorization request was not captured")
 	_, hasClientIP := capturedBody["clientIp"]
 	assert.False(t, hasClientIP, "gRPC stream path must not send clientIp")
 }

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	observability "github.com/LerianStudio/lib-observability/v2"
 	"github.com/LerianStudio/lib-observability/v2/log"
@@ -104,7 +106,7 @@ func TestCheckAuthorization_NormalUser_SubjectConstruction(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "action", token,
+		context.Background(), "midaz", "resource", "action", token, "",
 	)
 
 	require.NoError(t, err)
@@ -155,7 +157,7 @@ func TestCheckAuthorization_ApplicationUser_SubjectConstruction(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "my-app", "resource", "action", token,
+		context.Background(), "my-app", "resource", "action", token, "",
 	)
 
 	require.NoError(t, err)
@@ -209,7 +211,7 @@ func TestCheckAuthorization_Application_ForwardM2MProductEnabled_ForwardsProduct
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "action", token,
+		context.Background(), "midaz", "resource", "action", token, "",
 	)
 
 	require.NoError(t, err)
@@ -261,7 +263,7 @@ func TestCheckAuthorization_Application_ForwardM2MProductEnabled_EmptyProduct_No
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "", "resource", "action", token,
+		context.Background(), "", "resource", "action", token, "",
 	)
 
 	require.NoError(t, err)
@@ -292,7 +294,7 @@ func TestCheckAuthorization_MissingOwnerClaim(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "sub", "resource", "action", token,
+		context.Background(), "sub", "resource", "action", token, "",
 	)
 
 	require.Error(t, err)
@@ -325,7 +327,7 @@ func TestCheckAuthorization_MissingSubClaim(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "action", token,
+		context.Background(), "midaz", "resource", "action", token, "",
 	)
 
 	require.Error(t, err)
@@ -372,7 +374,7 @@ func TestCheckAuthorization_NormalUser_EmptyProduct_NotForwarded(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "", "resource", "action", token,
+		context.Background(), "", "resource", "action", token, "",
 	)
 
 	require.NoError(t, err)
@@ -405,7 +407,7 @@ func TestCheckAuthorization_MockServerReturnsAuthorizedTrue(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "sub", "resource", "read", token,
+		context.Background(), "sub", "resource", "read", token, "",
 	)
 
 	require.NoError(t, err)
@@ -432,7 +434,7 @@ func TestCheckAuthorization_MockServerReturnsAuthorizedFalse(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "sub", "resource", "read", token,
+		context.Background(), "sub", "resource", "read", token, "",
 	)
 
 	require.NoError(t, err)
@@ -475,7 +477,7 @@ func TestCheckAuthorization_MockServerReturnsForbiddenWithErrorBody(t *testing.T
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "sub", "resource", "write", token,
+		context.Background(), "sub", "resource", "write", token, "",
 	)
 
 	require.Error(t, err)
@@ -499,7 +501,7 @@ func TestCheckAuthorization_InvalidToken(t *testing.T) {
 	invalidToken := "not-a-valid-jwt"
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "sub", "resource", "action", invalidToken,
+		context.Background(), "sub", "resource", "action", invalidToken, "",
 	)
 
 	require.Error(t, err)
@@ -530,7 +532,7 @@ func TestCheckAuthorization_EmptyTypeClaim_Rejected(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "some-app", "resource", "action", token,
+		context.Background(), "some-app", "resource", "action", token, "",
 	)
 
 	require.Error(t, err)
@@ -562,7 +564,7 @@ func TestCheckAuthorization_ApplicationUser_MissingSubClaim_FailsClosed(t *testi
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "my-app", "resource", "action", token,
+		context.Background(), "my-app", "resource", "action", token, "",
 	)
 
 	require.Error(t, err)
@@ -594,7 +596,7 @@ func TestCheckAuthorization_NonCanonicalType_Rejected(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "action", token,
+		context.Background(), "midaz", "resource", "action", token, "",
 	)
 
 	require.Error(t, err)
@@ -623,7 +625,7 @@ func TestCheckAuthorization_MockServerDown(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "sub", "resource", "read", token,
+		context.Background(), "sub", "resource", "read", token, "",
 	)
 
 	require.Error(t, err)
@@ -656,7 +658,7 @@ func TestCheckAuthorization_ServerReturnsInvalidJSON(t *testing.T) {
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "sub", "resource", "read", token,
+		context.Background(), "sub", "resource", "read", token, "",
 	)
 
 	require.Error(t, err)
@@ -803,6 +805,201 @@ func TestAuthorize_FailClosed(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, reached, string(body))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Authorize - client IP forwarding (clientIp)
+// ---------------------------------------------------------------------------
+
+// TestAuthorize_ForwardsClientIP drives a request through the Fiber Authorize
+// middleware and asserts the caller IP resolved by c.IP() is forwarded to the
+// authorize endpoint as an OPTIONAL "clientIp" body field: present (== resolved
+// IP) when an IP is available, and ABSENT when the resolved IP is empty so the
+// wire body stays byte-identical to today for every deployed access-manager.
+func TestAuthorize_ForwardsClientIP(t *testing.T) {
+	t.Parallel()
+
+	// newApp builds a Fiber app whose c.IP() reads the X-Forwarded-For header.
+	// The in-memory test connection reports 0.0.0.0 as its remote address, so it
+	// is added to the trusted-proxy allowlist; this lets a test drive a known
+	// client IP (or an empty one, by omitting the header) deterministically.
+	newApp := func(auth *AuthClient) *fiber.App {
+		app := fiber.New(fiber.Config{
+			TrustProxy:       true,
+			TrustProxyConfig: fiber.TrustProxyConfig{Proxies: []string{"0.0.0.0"}},
+			ProxyHeader:      fiber.HeaderXForwardedFor,
+		})
+		app.Get("/x", auth.Authorize("midaz", "resource", "get"), func(c fiber.Ctx) error {
+			return c.SendString("reached handler")
+		})
+
+		return app
+	}
+
+	newCapturingServer := func(t *testing.T, captured *map[string]string) *httptest.Server {
+		t.Helper()
+
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(captured); err != nil {
+				t.Errorf("mock server: failed to decode request body: %v", err)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			if err := json.NewEncoder(w).Encode(AuthResponse{Authorized: true}); err != nil {
+				t.Errorf("mock server: failed to encode response: %v", err)
+			}
+		}))
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	})
+
+	t.Run("forwards_resolved_client_ip", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedBody map[string]string
+
+		server := newCapturingServer(t, &capturedBody)
+		defer server.Close()
+
+		auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
+
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set(fiber.HeaderXForwardedFor, "203.0.113.7")
+
+		resp, err := newApp(auth).Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// The resolved caller IP is forwarded as the optional clientIp field.
+		assert.Equal(t, "203.0.113.7", capturedBody["clientIp"])
+	})
+
+	t.Run("omits_client_ip_when_empty", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedBody map[string]string
+
+		server := newCapturingServer(t, &capturedBody)
+		defer server.Close()
+
+		auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
+
+		// No X-Forwarded-For header -> c.IP() resolves to "" -> key omitted.
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := newApp(auth).Test(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		_, hasClientIP := capturedBody["clientIp"]
+		assert.False(t, hasClientIP, "clientIp must be absent when the resolved IP is empty")
+	})
+}
+
+// TestAuthorize_DecisionCache_ScopedByClientIP proves the in-memory decision
+// cache keys entries by client IP, so an "authorized" decision cached for an
+// ALLOWED source IP is never served to a request from a DIFFERENT (blocked) IP
+// with the same {sub,resource,action,product}. The /v1/authorize decision is
+// IP-dependent (tenant IP-allowlist), so a cross-IP cache hit would bypass the
+// allowlist entirely. Same-IP requests must still be served from cache.
+func TestAuthorize_DecisionCache_ScopedByClientIP(t *testing.T) {
+	t.Parallel()
+
+	const (
+		allowedIP = "203.0.113.7"
+		blockedIP = "198.51.100.9"
+	)
+
+	// newApp builds a Fiber app whose c.IP() reads X-Forwarded-For (the in-memory
+	// test connection reports 0.0.0.0, added to the trusted-proxy allowlist), so a
+	// test can drive a known client IP deterministically.
+	newApp := func(auth *AuthClient) *fiber.App {
+		app := fiber.New(fiber.Config{
+			TrustProxy:       true,
+			TrustProxyConfig: fiber.TrustProxyConfig{Proxies: []string{"0.0.0.0"}},
+			ProxyHeader:      fiber.HeaderXForwardedFor,
+		})
+		app.Get("/x", auth.Authorize("midaz", "resource", "get"), func(c fiber.Ctx) error {
+			return c.SendString("reached handler")
+		})
+
+		return app
+	}
+
+	// ipAllowlistServer mimics the access-manager tenant IP-allowlist: it authorizes
+	// only requests whose forwarded clientIp equals allowedIP. It counts hits so a
+	// cache HIT (no request) is distinguishable from a cache MISS (a request).
+	ipAllowlistServer := func(t *testing.T) (*httptest.Server, *atomic.Int64) {
+		return countingAuthServer(t, func(w http.ResponseWriter, r *http.Request, _ int64) {
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("mock server: failed to decode request body: %v", err)
+			}
+
+			writeAuthorized(w, body["clientIp"] == allowedIP)
+		})
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	})
+
+	doGet := func(app *fiber.App, ip string) *http.Response {
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set(fiber.HeaderXForwardedFor, ip)
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+
+		return resp
+	}
+
+	t.Run("cross_ip_is_a_cache_miss_and_denied", func(t *testing.T) {
+		t.Parallel()
+
+		server, hits := ipAllowlistServer(t)
+		auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}, cache: newDecisionCache(time.Minute)}
+		app := newApp(auth)
+
+		// Request 1 from the ALLOWED IP: authorized and cached.
+		resp1 := doGet(app, allowedIP)
+		assert.Equal(t, http.StatusOK, resp1.StatusCode)
+
+		// Request 2 from a BLOCKED IP, identical sub/resource/action. With the IP in
+		// the cache key this is a MISS -> the server is re-queried and denies. Without
+		// the IP in the key it would be served the cached allow -> the bypass.
+		resp2 := doGet(app, blockedIP)
+		assert.Equal(t, http.StatusForbidden, resp2.StatusCode, "a blocked IP must not be served the allow cached for a different IP")
+		assert.Equal(t, int64(2), hits.Load(), "the blocked-IP request must re-query the authz service (cache miss on a different IP)")
+	})
+
+	t.Run("same_ip_is_served_from_cache", func(t *testing.T) {
+		t.Parallel()
+
+		server, hits := ipAllowlistServer(t)
+		auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}, cache: newDecisionCache(time.Minute)}
+		app := newApp(auth)
+
+		// Two identical requests from the SAME allowed IP: the second is served from
+		// cache, so the authz service is queried exactly once.
+		for i := 0; i < 2; i++ {
+			resp := doGet(app, allowedIP)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		}
+
+		assert.Equal(t, int64(1), hits.Load(), "a repeat request from the same IP must be served from cache (no second query)")
 	})
 }
 

--- a/auth/middleware/resilience_test.go
+++ b/auth/middleware/resilience_test.go
@@ -149,7 +149,7 @@ func TestCheckAuthorization_CacheHit_AvoidsSecondPost(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+		authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 		require.NoError(t, err)
 		assert.True(t, authorized)
 		assert.Equal(t, http.StatusOK, statusCode)
@@ -172,12 +172,12 @@ func TestCheckAuthorization_CacheExpiry_RequeriesAuthz(t *testing.T) {
 		cache:   newDecisionCache(15 * time.Millisecond),
 	}
 
-	_, _, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+	_, _, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 	require.NoError(t, err)
 
 	time.Sleep(40 * time.Millisecond)
 
-	_, _, err = auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+	_, _, err = auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(2), hits.Load(), "an expired cache entry must trigger a fresh authz query")
@@ -198,7 +198,7 @@ func TestCheckAuthorization_NegativeCache_Served(t *testing.T) {
 	}
 
 	for i := 0; i < 2; i++ {
-		authorized, _, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+		authorized, _, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 		require.NoError(t, err)
 		assert.False(t, authorized)
 	}
@@ -231,7 +231,7 @@ func TestCheckAuthorization_Retry_On5xx_EventuallySucceeds(t *testing.T) {
 		retryMax: 2,
 	}
 
-	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 
 	require.NoError(t, err)
 	assert.True(t, authorized)
@@ -256,7 +256,7 @@ func TestCheckAuthorization_Retry_NotOn403(t *testing.T) {
 		retryMax: 3,
 	}
 
-	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "write", userToken())
+	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "write", userToken(), "")
 
 	require.Error(t, err)
 	assert.False(t, authorized)
@@ -284,14 +284,14 @@ func TestCheckAuthorization_Breaker_OpensAfterN_AndDenies(t *testing.T) {
 
 	// Two consecutive transient (5xx) failures trip the breaker.
 	for i := 0; i < 2; i++ {
-		authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+		authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 		require.NoError(t, err, "runtime outage denies without surfacing an error")
 		assert.False(t, authorized)
 		assert.Equal(t, http.StatusForbidden, statusCode)
 	}
 
 	// Breaker now open: the next call is denied WITHOUT touching the authz service.
-	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 	require.NoError(t, err)
 	assert.False(t, authorized)
 	assert.Equal(t, http.StatusForbidden, statusCode)
@@ -323,7 +323,7 @@ func TestCheckAuthorization_BreakerOpen_ServesFreshPositiveCacheOnly(t *testing.
 	}
 
 	// Phase 1: prime a positive decision for "resCached" while the service is healthy.
-	authorized, _, err := auth.checkAuthorization(context.Background(), "", "resCached", "read", userToken())
+	authorized, _, err := auth.checkAuthorization(context.Background(), "", "resCached", "read", userToken(), "")
 	require.NoError(t, err)
 	require.True(t, authorized)
 
@@ -331,20 +331,20 @@ func TestCheckAuthorization_BreakerOpen_ServesFreshPositiveCacheOnly(t *testing.
 	failing.Store(true)
 
 	for i := 0; i < 2; i++ {
-		_, _, err = auth.checkAuthorization(context.Background(), "", "resTrip", "read", userToken())
+		_, _, err = auth.checkAuthorization(context.Background(), "", "resTrip", "read", userToken(), "")
 		require.NoError(t, err)
 	}
 
 	hitsAfterTrip := hits.Load()
 
 	// Breaker open + fresh positive cache hit -> allow (served from cache, no network).
-	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "resCached", "read", userToken())
+	authorized, statusCode, err := auth.checkAuthorization(context.Background(), "", "resCached", "read", userToken(), "")
 	require.NoError(t, err)
 	assert.True(t, authorized, "a fresh positive cache hit is served even while the breaker is open")
 	assert.Equal(t, http.StatusOK, statusCode)
 
 	// Breaker open + no cache -> deny.
-	authorized, statusCode, err = auth.checkAuthorization(context.Background(), "", "resUncached", "read", userToken())
+	authorized, statusCode, err = auth.checkAuthorization(context.Background(), "", "resUncached", "read", userToken(), "")
 	require.NoError(t, err)
 	assert.False(t, authorized, "with the breaker open and no fresh cache, the request is denied")
 	assert.Equal(t, http.StatusForbidden, statusCode)
@@ -378,7 +378,7 @@ func TestCheckAuthorization_ContextTimeout_AbortsCall(t *testing.T) {
 	}
 
 	start := time.Now()
-	authorized, _, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken())
+	authorized, _, err := auth.checkAuthorization(context.Background(), "", "res", "read", userToken(), "")
 	elapsed := time.Since(start)
 
 	require.Error(t, err, "the per-request deadline must abort the authz call")
@@ -415,7 +415,7 @@ func TestCheckAuthorization_CallerCancellation_Propagates(t *testing.T) {
 	}()
 
 	start := time.Now()
-	_, _, err := auth.checkAuthorization(ctx, "", "res", "read", userToken())
+	_, _, err := auth.checkAuthorization(ctx, "", "res", "read", userToken(), "")
 	elapsed := time.Since(start)
 
 	require.Error(t, err)

--- a/auth/middleware/verification_test.go
+++ b/auth/middleware/verification_test.go
@@ -312,7 +312,7 @@ func TestCheckAuthorization_VerificationEnabled_ValidToken_ReachesAuthz(t *testi
 	token := signRS256(t, key, normalUserClaims())
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "read", token,
+		context.Background(), "midaz", "resource", "read", token, "",
 	)
 
 	require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestCheckAuthorization_VerificationEnabled_ForgedToken_DeniedBeforeAuthz(t 
 	token := signRS256(t, attackerKey, normalUserClaims())
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "read", token,
+		context.Background(), "midaz", "resource", "read", token, "",
 	)
 
 	require.Error(t, err)
@@ -377,7 +377,7 @@ func TestCheckAuthorization_VerificationEnabled_ExpiredToken_Denied(t *testing.T
 	token := signRS256(t, key, claims)
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "read", token,
+		context.Background(), "midaz", "resource", "read", token, "",
 	)
 
 	require.Error(t, err)
@@ -408,7 +408,7 @@ func TestCheckAuthorization_VerificationDisabled_UnsignedTokenStillWorks(t *test
 	})
 
 	authorized, statusCode, err := auth.checkAuthorization(
-		context.Background(), "midaz", "resource", "read", token,
+		context.Background(), "midaz", "resource", "read", token, "",
 	)
 
 	require.NoError(t, err)


### PR DESCRIPTION
The Fiber Authorize closure captures c.IP() and forwards it as an OPTIONAL clientIp in the /v1/authorize body (omitted when empty -> backward-compatible; gRPC sends none, a follow-up epic). clientIp is added to the decision-cache key so a cached ALLOW for one IP is never served to another IP (closes a cross-IP cache bypass). Consumers own their Fiber trusted-proxy config. Epic 3.1 of the tenant-ip-allowlist feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)