### PR TITLE
chore(middleware): back-merge main (v3.1.0 M2M inversion flag) into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.1.0](https://github.com/LerianStudio/lib-auth/compare/v3.0.0...v3.1.0) (2026-07-24)
+
+
+### Features
+
+* **middleware:** opt-in flag for M2M inversion ([55c23ee](https://github.com/LerianStudio/lib-auth/commit/55c23eea505c248ea1ce4884f506e84bbb112478)), closes [#122](https://github.com/LerianStudio/lib-auth/issues/122) [pre-#122](https://github.com/LerianStudio/pre-/issues/122)
+
 ## [3.0.0](https://github.com/LerianStudio/lib-auth/compare/v2.9.0...v3.0.0) (2026-07-22)
 
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ PLUGIN_AUTH_ENABLED=true
 # false, preserving the previous behavior of sending no product for M2M.
 AUTH_M2M_PRODUCT_FORWARD_ENABLED=false
 
+# Optional. When "true", enables the M2M/authz "inversion of responsibility"
+# model: application tokens authorize under their own real sub claim and any token
+# type outside {normal-user, application} fails closed with 401. Defaults to false,
+# preserving the legacy pre-inversion model (non-normal-user types authorize under
+# the fabricated "admin/{product}-editor-role" subject and unknown types fail open).
+# Keep it false when your Casdoor seed still uses the legacy model; opt in once
+# seeds are migrated.
+AUTH_M2M_INVERSION_ENABLED=false
+
 # Optional. Opt-in local JWT signature verification for the general authorization
 # path. When unset, tokens are parsed without signature verification (the
 # authorization service remains the trust anchor) — the previous behavior,

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -42,6 +42,19 @@ type AuthClient struct {
 	// product isolation without a code change in consumers.
 	ForwardM2MProduct bool
 
+	// M2MInversionEnabled, when true, selects the "inversion of responsibility"
+	// M2M/authz model (#122): an application-type token authorizes under its own
+	// real sub claim and any token type outside {normal-user, application} fails
+	// closed with 401. When false (the DEFAULT) the legacy pre-#122 model is used:
+	// any non-normal-user type is treated as M2M and authorizes under the fabricated
+	// "admin/{product}-editor-role" subject, and an unknown/empty type is never
+	// rejected (fail open). It is read once from AUTH_M2M_INVERSION_ENABLED at
+	// construction; the default (false) preserves the prior behavior exactly, so a
+	// consumer bumping this library for Fiber v3 is NOT forced into the new authz
+	// model. Gating it by env keeps deploy != release: flipping the flag activates
+	// the inversion without a code change in consumers.
+	M2MInversionEnabled bool
+
 	// Required, when true, makes the middleware fail closed: if auth is disabled
 	// or misconfigured (!Enabled || Address == ""), every protected route refuses
 	// to serve (HTTP 503 / gRPC Unavailable) instead of passing through with
@@ -226,17 +239,18 @@ func NewAuthClient(address string, enabled bool, logger *log.Logger) *AuthClient
 	// Build the client once with all env-derived config, then return it from every
 	// path below; the health check only logs, it never changes these fields.
 	c := &AuthClient{
-		Address:           address,
-		Enabled:           enabled,
-		Logger:            l,
-		ForwardM2MProduct: os.Getenv("AUTH_M2M_PRODUCT_FORWARD_ENABLED") == "true",
-		Required:          os.Getenv("AUTH_REQUIRED") == "true",
-		timeout:           parseAuthTimeout(),
-		cache:             newDecisionCacheFromEnv(),
-		breaker:           newBreakerFromEnv(),
-		retryMax:          parseRetryMax(),
-		verifyKeys:        verifyKeys,
-		verifyIssuer:      verifyIssuer,
+		Address:             address,
+		Enabled:             enabled,
+		Logger:              l,
+		ForwardM2MProduct:   os.Getenv("AUTH_M2M_PRODUCT_FORWARD_ENABLED") == "true",
+		M2MInversionEnabled: os.Getenv("AUTH_M2M_INVERSION_ENABLED") == "true",
+		Required:            os.Getenv("AUTH_REQUIRED") == "true",
+		timeout:             parseAuthTimeout(),
+		cache:               newDecisionCacheFromEnv(),
+		breaker:             newBreakerFromEnv(),
+		retryMax:            parseRetryMax(),
+		verifyKeys:          verifyKeys,
+		verifyIssuer:        verifyIssuer,
 	}
 
 	if !enabled || address == "" {
@@ -357,15 +371,31 @@ func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handle
 }
 
 // deriveSubject builds the authorization subject from the token claims based on
-// the whitelisted token type. It fails closed (401) for any type outside
-// {normal-user, application}:
+// the token type. Its behavior is gated by AUTH_M2M_INVERSION_ENABLED
+// (auth.M2MInversionEnabled):
+//
+// Inversion OFF (default, legacy pre-#122): fail OPEN on type. Any type other than
+// normal-user is treated as M2M and yields the fabricated product-scoped role
+// "admin/<product>-editor-role"; an unknown/empty type is never rejected.
+//
+// Inversion ON (current v3.0.0): fail CLOSED on type. Only {normal-user,
+// application} are whitelisted:
 //   - normal-user: the JWT identity ("<owner>/<userID>"), failing closed with 401
 //     when the owner or sub claim is missing.
 //   - application (M2M): the token's own sub claim (already in "<owner>/<name>"
 //     form), failing closed with 401 when sub is missing. No product-scoped role
 //     is fabricated, since M2M has no product isolation.
 //   - any other type (including empty/absent): rejected with 401.
-func (auth *AuthClient) deriveSubject(ctx context.Context, span trace.Span, claims jwt.MapClaims, userType string) (string, int, error) {
+//
+// The normal-user branch is identical in both modes.
+func (auth *AuthClient) deriveSubject(ctx context.Context, span trace.Span, claims jwt.MapClaims, userType, product string) (string, int, error) {
+	if !auth.M2MInversionEnabled && userType != normalUser {
+		// LEGACY (pre-#122): any non-normal-user type is treated as M2M and
+		// authorizes under a fabricated product-scoped editor role. The type is
+		// never rejected (fail open) and the token's real sub is not consulted.
+		return fmt.Sprintf("admin/%s-editor-role", product), http.StatusOK, nil
+	}
+
 	switch userType {
 	case normalUser:
 		owner, _ := claims["owner"].(string)
@@ -451,7 +481,7 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 
 	userType, _ := claims["type"].(string)
 
-	sub, statusCode, err := auth.deriveSubject(ctx, span, claims, userType)
+	sub, statusCode, err := auth.deriveSubject(ctx, span, claims, userType, product)
 	if err != nil {
 		return false, statusCode, err
 	}
@@ -462,7 +492,11 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 		"action":   action,
 	}
 
-	if shouldForwardProduct(userType, product, auth.ForwardM2MProduct) {
+	// M2M product forwarding only applies under the inversion model; the legacy
+	// path (inversion OFF) forwards product for normal-user flows only (pre-#122).
+	// shouldForwardProduct(userType, product, false) == the legacy normal-user rule.
+	forwardM2MProduct := auth.ForwardM2MProduct && auth.M2MInversionEnabled
+	if shouldForwardProduct(userType, product, forwardM2MProduct) {
 		requestBody["product"] = product
 	}
 

--- a/auth/middleware/middlewareGRPC_test.go
+++ b/auth/middleware/middlewareGRPC_test.go
@@ -918,9 +918,10 @@ func TestNewGRPCAuthUnaryPolicy_ApplicationSubject(t *testing.T) {
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address: server.URL,
-		Enabled: true,
-		Logger:  &testLogger{},
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: true,
 	}
 
 	token := createTestJWT(jwt.MapClaims{
@@ -958,7 +959,7 @@ func TestNewGRPCAuthUnaryPolicy_ApplicationSubject(t *testing.T) {
 
 	// Subject is the real sub of the application token.
 	assert.Equal(t, "acme-org/my-app", capturedBody["sub"])
-	// Product is not forwarded for M2M tokens when the flag is off (default).
+	// Product is not forwarded for M2M tokens when ForwardM2MProduct is off (default).
 	_, hasProduct := capturedBody["product"]
 	assert.False(t, hasProduct)
 }
@@ -986,10 +987,11 @@ func TestNewGRPCAuthUnaryPolicy_ApplicationSubject_ForwardM2MProductEnabled(t *t
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address:           server.URL,
-		Enabled:           true,
-		Logger:            &testLogger{},
-		ForwardM2MProduct: true,
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		ForwardM2MProduct:   true,
+		M2MInversionEnabled: true,
 	}
 
 	token := createTestJWT(jwt.MapClaims{

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -143,9 +143,10 @@ func TestCheckAuthorization_ApplicationUser_SubjectConstruction(t *testing.T) {
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address: server.URL,
-		Enabled: true,
-		Logger:  &testLogger{},
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: true,
 	}
 
 	token := createTestJWT(jwt.MapClaims{
@@ -196,10 +197,11 @@ func TestCheckAuthorization_Application_ForwardM2MProductEnabled_ForwardsProduct
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address:           server.URL,
-		Enabled:           true,
-		Logger:            &testLogger{},
-		ForwardM2MProduct: true,
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		ForwardM2MProduct:   true,
+		M2MInversionEnabled: true,
 	}
 
 	token := createTestJWT(jwt.MapClaims{
@@ -248,10 +250,11 @@ func TestCheckAuthorization_Application_ForwardM2MProductEnabled_EmptyProduct_No
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address:           server.URL,
-		Enabled:           true,
-		Logger:            &testLogger{},
-		ForwardM2MProduct: true,
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		ForwardM2MProduct:   true,
+		M2MInversionEnabled: true,
 	}
 
 	token := createTestJWT(jwt.MapClaims{
@@ -519,9 +522,10 @@ func TestCheckAuthorization_EmptyTypeClaim_Rejected(t *testing.T) {
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address: server.URL,
-		Enabled: true,
-		Logger:  &testLogger{},
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: true,
 	}
 
 	// No "type" claim at all -> defaults to empty string -> not whitelisted.
@@ -550,9 +554,10 @@ func TestCheckAuthorization_ApplicationUser_MissingSubClaim_FailsClosed(t *testi
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address: server.URL,
-		Enabled: true,
-		Logger:  &testLogger{},
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: true,
 	}
 
 	token := createTestJWT(jwt.MapClaims{
@@ -582,9 +587,10 @@ func TestCheckAuthorization_NonCanonicalType_Rejected(t *testing.T) {
 	defer server.Close()
 
 	auth := &AuthClient{
-		Address: server.URL,
-		Enabled: true,
-		Logger:  &testLogger{},
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: true,
 	}
 
 	token := createTestJWT(jwt.MapClaims{
@@ -892,4 +898,279 @@ func TestAuthResponse_JSONRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, original.Authorized, decoded.Authorized)
+}
+
+// ---------------------------------------------------------------------------
+// AUTH_M2M_INVERSION_ENABLED - M2M/authz inversion toggle
+// ---------------------------------------------------------------------------
+
+// captureAuthServer returns a mock /v1/authorize server that decodes the request
+// body into capturedBody and always authorizes. Reaching it proves the type was
+// NOT rejected before the backend call (fail-open).
+func captureAuthServer(t *testing.T, capturedBody *map[string]string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(capturedBody); err != nil {
+			t.Errorf("mock server: failed to decode request body: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		if err := json.NewEncoder(w).Encode(AuthResponse{Authorized: true}); err != nil {
+			t.Errorf("mock server: failed to encode response: %v", err)
+		}
+	}))
+}
+
+func TestCheckAuthorization_M2MInversionOff_ApplicationGetsEditorRole(t *testing.T) {
+	t.Parallel()
+
+	// Legacy (pre-#122) behavior with the inversion flag OFF (default): an
+	// application (M2M) token yields the fabricated product-scoped role
+	// "admin/<product>-editor-role" and the real sub is NOT used.
+	var capturedBody map[string]string
+
+	server := captureAuthServer(t, &capturedBody)
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: false,
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type": "application",
+		"name": "my-app",
+		"sub":  "acme-org/my-app",
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "midaz", "resource", "action", token,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, authorized)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "admin/midaz-editor-role", capturedBody["sub"])
+	// Legacy forwards product only for normal-user, never for M2M.
+	_, hasProduct := capturedBody["product"]
+	assert.False(t, hasProduct)
+}
+
+func TestCheckAuthorization_M2MInversionOff_UnknownType_FailsOpen(t *testing.T) {
+	t.Parallel()
+
+	// Legacy (pre-#122) fail-open behavior: any non-normal-user type (including an
+	// unknown one) is treated as M2M and yields the editor role. It is NEVER
+	// rejected on type and DOES reach the backend.
+	var capturedBody map[string]string
+
+	server := captureAuthServer(t, &capturedBody)
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: false,
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "service-account",
+		"owner": "acme-org",
+		"sub":   "svc-1",
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "midaz", "resource", "action", token,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, authorized)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "admin/midaz-editor-role", capturedBody["sub"])
+}
+
+func TestCheckAuthorization_M2MInversionOff_EmptyType_FailsOpen(t *testing.T) {
+	t.Parallel()
+
+	// An absent "type" claim is also non-normal-user under the legacy path, so it
+	// fails open with the editor role rather than returning 401.
+	var capturedBody map[string]string
+
+	server := captureAuthServer(t, &capturedBody)
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: false,
+	}
+
+	// No "type" claim -> empty string -> non-normal-user under legacy.
+	token := createTestJWT(jwt.MapClaims{
+		"sub": "some-app",
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "midaz", "resource", "action", token,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, authorized)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "admin/midaz-editor-role", capturedBody["sub"])
+}
+
+func TestCheckAuthorization_M2MInversionOn_ApplicationGetsRealSub(t *testing.T) {
+	t.Parallel()
+
+	// Inversion ON: an application (M2M) token is identified by its real sub claim;
+	// no product-scoped role is fabricated.
+	var capturedBody map[string]string
+
+	server := captureAuthServer(t, &capturedBody)
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: true,
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type": "application",
+		"name": "my-app",
+		"sub":  "acme-org/my-app",
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "midaz", "resource", "action", token,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, authorized)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "acme-org/my-app", capturedBody["sub"])
+}
+
+func TestCheckAuthorization_M2MInversionOn_UnknownType_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	// Inversion ON: any type outside {normal-user, application} fails closed with
+	// 401 and never reaches the backend.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("auth backend must not be called for a non-canonical token type under inversion")
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{
+		Address:             server.URL,
+		Enabled:             true,
+		Logger:              &testLogger{},
+		M2MInversionEnabled: true,
+	}
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "service-account",
+		"owner": "acme-org",
+		"sub":   "svc-1",
+	})
+
+	authorized, statusCode, err := auth.checkAuthorization(
+		context.Background(), "midaz", "resource", "action", token,
+	)
+
+	require.Error(t, err)
+	assert.False(t, authorized)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Contains(t, err.Error(), "unsupported token type")
+}
+
+func TestCheckAuthorization_M2MInversion_NormalUserUnchanged(t *testing.T) {
+	t.Parallel()
+
+	// normal-user behavior is identical in both modes: subject is the JWT identity
+	// "<owner>/<userID>" and the product is forwarded.
+	tests := []struct {
+		name      string
+		inversion bool
+	}{
+		{name: "inversion_off", inversion: false},
+		{name: "inversion_on", inversion: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedBody map[string]string
+
+			server := captureAuthServer(t, &capturedBody)
+			defer server.Close()
+
+			auth := &AuthClient{
+				Address:             server.URL,
+				Enabled:             true,
+				Logger:              &testLogger{},
+				M2MInversionEnabled: tt.inversion,
+			}
+
+			token := createTestJWT(jwt.MapClaims{
+				"type":  "normal-user",
+				"owner": "acme-org",
+				"sub":   "user123",
+			})
+
+			authorized, statusCode, err := auth.checkAuthorization(
+				context.Background(), "midaz", "resource", "action", token,
+			)
+
+			require.NoError(t, err)
+			assert.True(t, authorized)
+			assert.Equal(t, http.StatusOK, statusCode)
+			assert.Equal(t, "acme-org/user123", capturedBody["sub"])
+			assert.Equal(t, "midaz", capturedBody["product"])
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewAuthClient - M2MInversionEnabled (AUTH_M2M_INVERSION_ENABLED) flag
+// ---------------------------------------------------------------------------
+
+func TestNewAuthClient_ReadsM2MInversionFlag(t *testing.T) {
+	// Cannot use t.Parallel(): subtests use t.Setenv which modifies process env.
+	// enabled=false / empty address returns early without any network call, so the
+	// flag wiring is exercised in isolation.
+	logger := log.Logger(&testLogger{})
+
+	t.Run("flag_true_enables_inversion", func(t *testing.T) {
+		t.Setenv("AUTH_M2M_INVERSION_ENABLED", "true")
+
+		client := NewAuthClient("", false, &logger)
+		assert.True(t, client.M2MInversionEnabled)
+	})
+
+	t.Run("flag_absent_defaults_false", func(t *testing.T) {
+		t.Setenv("AUTH_M2M_INVERSION_ENABLED", "")
+
+		client := NewAuthClient("", false, &logger)
+		assert.False(t, client.M2MInversionEnabled)
+	})
+
+	t.Run("flag_non_true_value_is_false", func(t *testing.T) {
+		t.Setenv("AUTH_M2M_INVERSION_ENABLED", "1")
+
+		client := NewAuthClient("", false, &logger)
+		assert.False(t, client.M2MInversionEnabled)
+	})
 }


### PR DESCRIPTION
## What & why

Back-merges `main` into `develop` after the `v3.1.0` hotfix (#133), which added the opt-in `AUTH_M2M_INVERSION_ENABLED` flag directly on `main`. Without this, `develop` does not carry the flag and the next `develop → main` release would drop it (regression).

## Why manual

The automated `semantic-release-backmerge` step ran on the `#133` release but **failed** — it uses a *rebase* strategy and its push was rejected as non-fast-forward:

```
git push ... HEAD:develop
 ! [rejected]  HEAD -> develop (non-fast-forward)
```

This is structural for a hotfix landed directly on `main` (the same class failed for the earlier hotfix #111). Re-running the release job would fail identically. A PR merge is the sanctioned path to update `develop` and does not hit the non-fast-forward wall.

## What was reconciled

The code auto-merged cleanly (`develop`'s 6-arg `checkAuthorization(ctx, product, resource, action, accessToken, clientIP)` is the superset; `main`'s hotfix carried the same minus `clientIP`). Two resolutions:

1. **`CHANGELOG.md`** (the only textual conflict): union — `3.1.0` section above `3.1.0-beta.1`.
2. **`middleware_test.go`**: `main`'s six new `TestCheckAuthorization_M2MInversion*` tests were written against the 5-arg signature; each gained the trailing `clientIP=""` (subject/role/type tests, no IP dimension — matching how `develop`'s own non-IP tests thread `clientIP=""`). No production code changed.

Both features remain covered and non-vacuous: the M2M inversion flag (OFF = legacy `admin/<product>-editor-role` fail-open; ON = real `sub` + type-whitelist fail-closed) **and** #132's client-IP forwarding + IP-keyed decision cache.

## Verification

- `go build ./...` — clean
- `go test -race ./...` — pass
- `golangci-lint run ./...` — 0 issues

## Note

`develop` was on `3.1.0-beta.1` and `main` took `3.1.0` stable; after this merge semantic-release on `develop` will recompute the next prerelease (likely `3.2.0-beta.1`). Expected, not a problem.
