### PR TITLE
fix(middleware): keep the caller IP out of the tracing span

### DIFF
--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -520,7 +520,21 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 		requestBody["clientIp"] = clientIP
 	}
 
-	err = tracing.SetSpanAttributesFromValue(span, "app.request.payload", requestBody, nil)
+	// The span payload omits clientIp: a caller IP is personal data, and traces
+	// are retained longer and read more widely than authz logs. Same split as
+	// getApplicationToken, which keeps the client secret out of the span while
+	// the wire body carries it. The wire body below is unchanged.
+	tracePayload := make(map[string]string, len(requestBody))
+
+	for k, v := range requestBody {
+		if k == "clientIp" {
+			continue
+		}
+
+		tracePayload[k] = v
+	}
+
+	err = tracing.SetSpanAttributesFromValue(span, "app.request.payload", tracePayload, nil)
 	if err != nil {
 		tracing.HandleSpanError(span, "Failed to convert request body to JSON string", err)
 

--- a/auth/middleware/middleware_test.go
+++ b/auth/middleware/middleware_test.go
@@ -898,7 +898,12 @@ func TestAuthorize_ForwardsClientIP(t *testing.T) {
 
 		auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
 
-		// No X-Forwarded-For header -> c.IP() resolves to "" -> key omitted.
+		// No X-Forwarded-For header: the only hop is the test connection's
+		// 0.0.0.0, which newApp lists as a trusted proxy, so the walk skips it
+		// and no untrusted address remains -> c.IP() resolves to "" -> key
+		// omitted. This is not a harness quirk: it mirrors fully-internal
+		// traffic, where every hop is a trusted proxy and no caller IP can be
+		// attributed, which is exactly what the empty-value guard exists for.
 		req := httptest.NewRequest(http.MethodGet, "/x", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
@@ -1012,6 +1017,80 @@ func TestAuthorize_DecisionCache_ScopedByClientIP(t *testing.T) {
 // ---------------------------------------------------------------------------
 // GetApplicationToken
 // ---------------------------------------------------------------------------
+
+// TestAuthorize_DoesNotTraceClientIP proves the caller IP reaches the wire body
+// but never a span attribute. A client IP is personal data, and traces are
+// retained longer and read more widely than authz logs, so the span payload is
+// emitted from a copy with clientIp stripped.
+func TestAuthorize_DoesNotTraceClientIP(t *testing.T) {
+	t.Parallel()
+
+	const clientIP = "203.0.113.7"
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+
+	var capturedBody map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		require.NoError(t, json.NewEncoder(w).Encode(AuthResponse{Authorized: true}))
+	}))
+	defer server.Close()
+
+	auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
+
+	app := fiber.New(fiber.Config{
+		TrustProxy:       true,
+		TrustProxyConfig: fiber.TrustProxyConfig{Proxies: []string{"0.0.0.0"}},
+		ProxyHeader:      fiber.HeaderXForwardedFor,
+	})
+
+	// Seed the tracer the middleware recovers from the request context.
+	app.Use(func(c fiber.Ctx) error {
+		c.SetContext(observability.ContextWithTracer(c.Context(), tp.Tracer("test")))
+
+		return c.Next()
+	})
+	app.Get("/x", auth.Authorize("midaz", "resource", "get"), func(c fiber.Ctx) error {
+		return c.SendString("reached handler")
+	})
+
+	token := createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set(fiber.HeaderXForwardedFor, clientIP)
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The wire body still carries the IP — enforcement depends on it.
+	assert.Equal(t, clientIP, capturedBody["clientIp"])
+
+	// No span attribute may expose it, by key or by value.
+	spans := exporter.GetSpans()
+	require.NotEmpty(t, spans, "expected the authorization spans to be exported")
+
+	for _, s := range spans {
+		for _, attr := range s.Attributes {
+			assert.NotContains(t, string(attr.Key), "clientIp",
+				"span %q exposes a clientIp attribute", s.Name)
+			assert.NotContains(t, attr.Value.AsString(), clientIP,
+				"span %q leaks the caller IP in attribute %q", s.Name, attr.Key)
+		}
+	}
+}
 
 func TestGetApplicationToken_DoesNotTraceClientSecret(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Addresses the CodeRabbit review on #136.

## The leak

`checkAuthorization` passes the same map to both the wire and the span:

```go
if clientIP != "" { requestBody["clientIp"] = clientIP }
err = tracing.SetSpanAttributesFromValue(span, "app.request.payload", requestBody, nil)
```

So adding `clientIp` put the caller IP on **every** authorization span — `app.request.payload.clientIp`. A client IP is personal data under GDPR/LGPD, and traces are typically retained longer and read more widely than authz logs, so this was a new egress path introduced by the allowlist work.

## The fix

Emit the span payload from a copy with `clientIp` stripped. This mirrors `getApplicationToken`, which already builds a separate `tracePayload` so the client secret never reaches the span while the wire body carries it. **The wire body is unchanged** — enforcement is unaffected.

Covered by `TestAuthorize_DoesNotTraceClientIP`, which asserts the IP is present in the captured request body and absent from every exported span attribute, by key and by value. Verified RED against the unfixed code:

```
span "lib_auth.check_authorization" exposes a clientIp attribute
span "lib_auth.check_authorization" leaks the caller IP in attribute "app.request.payload.clientIp"
```

## On the other review comment

The `omits_client_ip_when_empty` subtest was flagged for expecting the field to disappear rather than asserting the connection's remote IP. The existing assertion is correct and passes: `newApp` lists the test connection's `0.0.0.0` as a **trusted proxy**, so the walk skips it, no untrusted address remains, and `c.IP()` returns `""`. That is not a harness quirk — it is what happens for fully-internal traffic where every hop is trusted, which is precisely the case the empty-value guard exists for. Only the comment was misleading; it now explains this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)