### PR TITLE
feat(declaration): add D7 declaration publisher (startup manifest push)

### DIFF
--- a/auth/declaration/manifest.go
+++ b/auth/declaration/manifest.go
@@ -1,0 +1,338 @@
+package declaration
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Permission effects. A permission either grants (allow) or refuses (deny) the
+// declared (resource, action) pair. These are the only accepted values. They
+// mirror the server model (plugin-access-manager identity pkg/model).
+const (
+	effectAllow = "allow"
+	effectDeny  = "deny"
+)
+
+// DeclarationManifest is the wire model for a plugin's access-manager declaration
+// (the body of PUT /v1/declarations/{slug}). It is a faithful client-side mirror of
+// the server model
+// (plugin-access-manager/components/identity/pkg/model/declaration.go): the JSON
+// tags are byte-identical so a marshalled manifest deserializes into the server's
+// DeclarationManifest, and CanonicalHash reproduces the server hash exactly.
+//
+// The struct additionally carries yaml tags so the authored permissions.yaml
+// (human form) parses into the same struct as the JSON wire form.
+type DeclarationManifest struct {
+	// Service the manifest belongs to. Matches the caller's token; the
+	// `plugin-` prefix is kept (not stripped). Required, non-empty.
+	Service string `json:"service,omitempty" yaml:"service,omitempty"`
+	// Version is advisory metadata. It is EXCLUDED from CanonicalHash, so a
+	// version bump with identical content hashes identically. Required, positive.
+	Version int `json:"version,omitempty" yaml:"version,omitempty"`
+	// Permissions declared by the plugin: one entry per (resource, action).
+	Permissions []DeclarationPermission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	// Roles declared by the plugin. Role names are free-form and may contain '/'.
+	Roles []DeclarationRole `json:"roles,omitempty" yaml:"roles,omitempty"`
+	// M2M is the plugin's bilateral machine-to-machine contract.
+	M2M *DeclarationM2M `json:"m2m,omitempty" yaml:"m2m,omitempty"`
+}
+
+// DeclarationPermission is a single declared permission. The action is SEMANTIC
+// (create/read/update/delete), never an HTTP verb. The resource is written bare;
+// the central reconciler composes the `{service}/` prefix.
+type DeclarationPermission struct {
+	Resource string   `json:"resource,omitempty" yaml:"resource,omitempty"`
+	Action   string   `json:"action,omitempty" yaml:"action,omitempty"`
+	Effect   string   `json:"effect,omitempty" yaml:"effect,omitempty"`
+	Roles    []string `json:"roles,omitempty" yaml:"roles,omitempty"`
+}
+
+// DeclarationRole is a role declared by the plugin. A role names itself and
+// optionally binds to already-existing groups via GrantedTo.
+type DeclarationRole struct {
+	Name      string             `json:"name,omitempty" yaml:"name,omitempty"`
+	GrantedTo []DeclarationGrant `json:"granted_to,omitempty" yaml:"granted_to,omitempty"`
+}
+
+// DeclarationGrant binds a role to an existing group. Members of the group
+// receive the role.
+type DeclarationGrant struct {
+	Group string `json:"group,omitempty" yaml:"group,omitempty"`
+}
+
+// DeclarationM2M is the plugin's bilateral machine-to-machine contract.
+type DeclarationM2M struct {
+	Exposed bool     `json:"exposed,omitempty" yaml:"exposed,omitempty"`
+	Needs   []string `json:"needs,omitempty" yaml:"needs,omitempty"`
+}
+
+// canonicalManifest is the deterministic, hashable projection of a manifest. It
+// deliberately OMITS Version so a version bump with identical content produces the
+// same hash. Field order is fixed by struct declaration and there are no maps, so
+// encoding/json emits a byte-stable form regardless of the ordering of keys in the
+// original wire payload.
+//
+// This mirrors the server's canonicalManifest exactly
+// (plugin-access-manager/components/identity/pkg/model/declaration.go:98) — the
+// json tags and field order MUST stay in lock-step with the server or the
+// idempotency-by-hash contract breaks. Note "service" carries NO omitempty, matching
+// the server.
+type canonicalManifest struct {
+	Service     string                  `json:"service"`
+	Permissions []DeclarationPermission `json:"permissions,omitempty"`
+	Roles       []DeclarationRole       `json:"roles,omitempty"`
+	M2M         *DeclarationM2M         `json:"m2m,omitempty"`
+}
+
+// ManifestError reports an invalid or unparseable manifest. It is the client-side
+// counterpart of the server's 422 (UnprocessableOperation): the same validation is
+// run eagerly at New so a bad embedded manifest fails fast instead of PUTting a
+// guaranteed-422 body.
+type ManifestError struct {
+	Reason string
+}
+
+func (e *ManifestError) Error() string {
+	return "declaration manifest invalid: " + e.Reason
+}
+
+// parseManifest parses the embedded manifest bytes (authored YAML or wire JSON)
+// into the manifest model. JSON is detected by a leading '{'; anything else is
+// treated as YAML. Both forms target the same struct (json/yaml tags are aligned),
+// so they produce an identical manifest and identical wire JSON.
+func parseManifest(raw []byte) (*DeclarationManifest, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, &ManifestError{Reason: "manifest is empty"}
+	}
+
+	var m DeclarationManifest
+
+	if trimmed[0] == '{' {
+		if err := json.Unmarshal(trimmed, &m); err != nil {
+			return nil, &ManifestError{Reason: fmt.Sprintf("parse json manifest: %v", err)}
+		}
+
+		return &m, nil
+	}
+
+	if err := yaml.Unmarshal(trimmed, &m); err != nil {
+		return nil, &ManifestError{Reason: fmt.Sprintf("parse yaml manifest: %v", err)}
+	}
+
+	return &m, nil
+}
+
+// wireJSON marshals the manifest into the JSON body PUT to the identity service.
+// The server deserializes it into its own DeclarationManifest (tags are aligned).
+func (m *DeclarationManifest) wireJSON() ([]byte, error) {
+	payload, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal wire manifest: %w", err)
+	}
+
+	return payload, nil
+}
+
+// CanonicalHash returns a stable hex-encoded SHA-256 over a deterministic
+// serialization of the manifest, EXCLUDING Version. Two manifests that differ only
+// in wire key ordering or in Version hash identically; any content difference
+// changes the hash.
+//
+// It is a byte-for-byte mirror of the server's
+// DeclarationManifest.CanonicalHash
+// (plugin-access-manager/components/identity/pkg/model/declaration.go:277): the
+// server stores this hex in the app's `declaration-hash` Tag and no-ops the PUT
+// when it matches, so the two implementations MUST agree.
+func (m *DeclarationManifest) CanonicalHash() (string, error) {
+	payload, err := json.Marshal(canonicalManifest{
+		Service:     m.Service,
+		Permissions: m.Permissions,
+		Roles:       m.Roles,
+		M2M:         m.M2M,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal canonical manifest: %w", err)
+	}
+
+	sum := sha256.Sum256(payload)
+
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// Validate performs structural validation and the permission->role cross-reference
+// checks, mirroring the server's Validate
+// (plugin-access-manager/.../pkg/model/declaration.go:136). Running it eagerly at
+// New surfaces a broken embedded manifest at boot instead of as a runtime 422.
+// All violations are aggregated into a single *ManifestError.
+func (m *DeclarationManifest) Validate() error {
+	var violations []string
+
+	if strings.TrimSpace(m.Service) == "" {
+		violations = append(violations, "service must not be empty")
+	}
+
+	if m.Version < 1 {
+		violations = append(violations, "version must be a positive integer")
+	}
+
+	declaredRoles, roleViolations := m.validateRoles()
+	violations = append(violations, roleViolations...)
+	violations = append(violations, m.validatePermissions(declaredRoles)...)
+
+	if len(violations) == 0 {
+		return nil
+	}
+
+	return &ManifestError{Reason: strings.Join(violations, "; ")}
+}
+
+// validateRoles validates each declared role and returns the set of declared role
+// names plus any violations. It enforces a non-empty name, no duplicate composed
+// name ("{service}/{name}"), and no two roles sharing the lossy Casdoor-safe
+// derivation of that composed name (nor a derivation collapsing to empty) — mirroring
+// the server so a manifest that passes here also passes the server's reconcile.
+func (m *DeclarationManifest) validateRoles() (map[string]struct{}, []string) {
+	var violations []string
+
+	declaredRoles := make(map[string]struct{}, len(m.Roles))
+	seenComposed := make(map[string]struct{}, len(m.Roles))
+	seenKebab := make(map[string]string, len(m.Roles))
+
+	for i, r := range m.Roles {
+		if strings.TrimSpace(r.Name) == "" {
+			violations = append(violations, fmt.Sprintf("roles[%d]: role name must not be empty", i))
+			continue
+		}
+
+		declaredRoles[r.Name] = struct{}{}
+
+		composed := m.Service + "/" + r.Name
+		if _, dup := seenComposed[composed]; dup {
+			violations = append(violations, fmt.Sprintf("roles[%d]: duplicate composed role name %q", i, composed))
+			continue
+		}
+
+		seenComposed[composed] = struct{}{}
+
+		switch kebab := casdoorSafeName(composed); kebab {
+		case "":
+			violations = append(violations, fmt.Sprintf("roles[%d]: role name %q derives an empty Casdoor-safe name", i, composed))
+		default:
+			if first, dup := seenKebab[kebab]; dup {
+				violations = append(violations, fmt.Sprintf("roles[%d]: role names %q and %q derive the same Casdoor-safe name %q", i, first, composed, kebab))
+			} else {
+				seenKebab[kebab] = composed
+			}
+		}
+	}
+
+	return declaredRoles, violations
+}
+
+// validatePermissions validates each declared permission against declaredRoles and
+// returns any violations. It enforces a non-empty resource and action, an
+// allow/deny effect, at least one granted (declared) role, no duplicate composed
+// name, and no lossy Casdoor-safe collision — mirroring the server.
+func (m *DeclarationManifest) validatePermissions(declaredRoles map[string]struct{}) []string {
+	var violations []string
+
+	seenComposed := make(map[string]struct{}, len(m.Permissions))
+	seenKebab := make(map[string]string, len(m.Permissions))
+
+	for i, p := range m.Permissions {
+		if strings.TrimSpace(p.Resource) == "" {
+			violations = append(violations, fmt.Sprintf("permissions[%d]: resource must not be empty", i))
+		}
+
+		if strings.TrimSpace(p.Action) == "" {
+			violations = append(violations, fmt.Sprintf("permissions[%d]: action must not be empty", i))
+		}
+
+		if p.Effect != effectAllow && p.Effect != effectDeny {
+			violations = append(violations, fmt.Sprintf("permissions[%d]: effect must be %q or %q", i, effectAllow, effectDeny))
+		}
+
+		if len(p.Roles) == 0 {
+			violations = append(violations, fmt.Sprintf("permissions[%d]: must grant to at least one role", i))
+		}
+
+		for _, roleRef := range p.Roles {
+			if _, ok := declaredRoles[roleRef]; !ok {
+				violations = append(violations, fmt.Sprintf("permissions[%d]: references undeclared role %q", i, roleRef))
+			}
+		}
+
+		composed := m.Service + "/" + p.Resource + ":" + p.Action
+		if _, dup := seenComposed[composed]; dup {
+			violations = append(violations, fmt.Sprintf("permissions[%d]: duplicate composed permission name %q", i, composed))
+			continue
+		}
+
+		seenComposed[composed] = struct{}{}
+
+		switch kebab := casdoorSafeName(composed); kebab {
+		case "":
+			violations = append(violations, fmt.Sprintf("permissions[%d]: permission name %q derives an empty Casdoor-safe name", i, composed))
+		default:
+			if first, dup := seenKebab[kebab]; dup {
+				violations = append(violations, fmt.Sprintf("permissions[%d]: permission names %q and %q derive the same Casdoor-safe name %q", i, first, composed, kebab))
+			} else {
+				seenKebab[kebab] = composed
+			}
+		}
+	}
+
+	return violations
+}
+
+// casdoorSafeName derives a deterministic, Casdoor-safe identity from the standard
+// slash/colon notation. Every forbidden char (and any run of separators, including
+// literal hyphens) collapses to a single "-"; leading/trailing separators are
+// trimmed. It mirrors the server's CasdoorSafeName so client-side validation agrees
+// with the server's create/lookup keying.
+func casdoorSafeName(standard string) string {
+	var b strings.Builder
+
+	b.Grow(len(standard))
+
+	prevHyphen := false
+
+	for _, r := range standard {
+		if r == '-' || isForbiddenNameChar(r) {
+			if prevHyphen {
+				continue
+			}
+
+			b.WriteByte('-')
+
+			prevHyphen = true
+
+			continue
+		}
+
+		b.WriteRune(r)
+
+		prevHyphen = false
+	}
+
+	return strings.Trim(b.String(), "-")
+}
+
+// isForbiddenNameChar reports whether r is rejected by Casdoor in a role or
+// permission name: the fixed forbidden set plus any Unicode whitespace.
+func isForbiddenNameChar(r rune) bool {
+	switch r {
+	case '/', '?', ':', '#', '&', '%', '=', '+', ';':
+		return true
+	}
+
+	return unicode.IsSpace(r)
+}

--- a/auth/declaration/manifest.go
+++ b/auth/declaration/manifest.go
@@ -179,6 +179,13 @@ func (m *DeclarationManifest) Validate() error {
 		violations = append(violations, "service must not be empty")
 	}
 
+	// A dot-segment service ("." or "..") survives url.PathEscape intact, so it would
+	// form /v1/declarations/.. and a path-normalizing intermediary could redirect the
+	// PUT to the wrong endpoint. New enforces slug==service, so guarding here covers both.
+	if m.Service == "." || m.Service == ".." {
+		violations = append(violations, fmt.Sprintf("service must not be a dot-segment %q", m.Service))
+	}
+
 	if m.Version < 1 {
 		violations = append(violations, "version must be a positive integer")
 	}

--- a/auth/declaration/manifest_test.go
+++ b/auth/declaration/manifest_test.go
@@ -152,6 +152,31 @@ func TestCanonicalHash_ContentChangeChangesHash(t *testing.T) {
 	assert.NotEqual(t, hBase, hMut, "any content change must change the hash")
 }
 
+// TestValidate_RejectsDotSegmentService asserts a manifest whose service is a
+// dot-segment ("." or "..") is rejected. url.PathEscape leaves these intact, so an
+// unguarded ".." would form /v1/declarations/.. and a path-normalizing intermediary
+// could redirect the PUT to the wrong endpoint. New enforces slug==service, so
+// guarding service in Validate covers both.
+func TestValidate_RejectsDotSegmentService(t *testing.T) {
+	tests := map[string]string{
+		"single dot": `{"service":".","version":1}`,
+		"double dot": `{"service":"..","version":1}`,
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			m, err := parseManifest([]byte(raw))
+			require.NoError(t, err)
+
+			verr := m.Validate()
+			require.Error(t, verr, "a dot-segment service must be rejected")
+
+			var me *ManifestError
+			assert.ErrorAs(t, verr, &me, "validation error must be a *ManifestError")
+		})
+	}
+}
+
 func TestValidate_Valid(t *testing.T) {
 	m, err := parseManifest([]byte(feesJSON))
 	require.NoError(t, err)

--- a/auth/declaration/manifest_test.go
+++ b/auth/declaration/manifest_test.go
@@ -1,0 +1,183 @@
+package declaration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// feesJSON mirrors ~/Downloads/RI-AM/local-test/plugin-fees.manifest.json — the
+// real wire fixture proven green by declare.sh.
+const feesJSON = `{
+  "service": "plugin-fees",
+  "version": 3,
+  "permissions": [
+    { "resource": "billing-packages", "action": "create", "effect": "allow", "roles": ["fees/editor"] },
+    { "resource": "billing-packages", "action": "read",   "effect": "allow", "roles": ["fees/editor", "fees/viewer"] },
+    { "resource": "billing-packages", "action": "delete", "effect": "deny",  "roles": ["fees/viewer"] }
+  ],
+  "roles": [
+    { "name": "fees/editor", "granted_to": [{ "group": "fees-admins" }] },
+    { "name": "fees/viewer", "granted_to": [{ "group": "fees-viewers" }] }
+  ],
+  "m2m": { "exposed": true, "needs": ["midaz"] }
+}`
+
+// feesYAML is the authored (human) form of the SAME manifest. The lib must parse
+// YAML or JSON into the same struct / same wire JSON.
+const feesYAML = `
+service: plugin-fees
+version: 3
+permissions:
+  - resource: billing-packages
+    action: create
+    effect: allow
+    roles: [fees/editor]
+  - resource: billing-packages
+    action: read
+    effect: allow
+    roles: [fees/editor, fees/viewer]
+  - resource: billing-packages
+    action: delete
+    effect: deny
+    roles: [fees/viewer]
+roles:
+  - name: fees/editor
+    granted_to:
+      - group: fees-admins
+  - name: fees/viewer
+    granted_to:
+      - group: fees-viewers
+m2m:
+  exposed: true
+  needs: [midaz]
+`
+
+func TestParseManifest_YAMLAndJSON_ProduceSameStructAndWire(t *testing.T) {
+	fromJSON, err := parseManifest([]byte(feesJSON))
+	require.NoError(t, err)
+
+	fromYAML, err := parseManifest([]byte(feesYAML))
+	require.NoError(t, err)
+
+	assert.Equal(t, fromJSON, fromYAML, "YAML and JSON must parse into an identical struct")
+
+	wireJSONBytes, err := fromJSON.wireJSON()
+	require.NoError(t, err)
+
+	wireYAMLBytes, err := fromYAML.wireJSON()
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(wireJSONBytes), string(wireYAMLBytes), "wire JSON must be identical")
+
+	// The wire JSON must deserialize back into the manifest model (server round-trip).
+	roundTrip, err := parseManifest(wireJSONBytes)
+	require.NoError(t, err)
+	assert.Equal(t, fromJSON, roundTrip)
+}
+
+func TestParseManifest_Invalid(t *testing.T) {
+	_, err := parseManifest([]byte("not: [valid: yaml"))
+	require.Error(t, err)
+
+	_, err = parseManifest([]byte("   "))
+	require.Error(t, err)
+}
+
+func TestCanonicalHash_ExcludesVersion(t *testing.T) {
+	v3, err := parseManifest([]byte(feesJSON))
+	require.NoError(t, err)
+
+	v99 := *v3
+	v99.Version = 99
+
+	h1, err := v3.CanonicalHash()
+	require.NoError(t, err)
+
+	h2, err := v99.CanonicalHash()
+	require.NoError(t, err)
+
+	assert.Equal(t, h1, h2, "manifests differing only in version must hash identically (R1)")
+	assert.Len(t, h1, 64, "hash must be hex-encoded sha256 (64 chars)")
+}
+
+func TestCanonicalHash_KeyOrderIndependent(t *testing.T) {
+	reordered := `{
+      "m2m": { "needs": ["midaz"], "exposed": true },
+      "roles": [
+        { "granted_to": [{ "group": "fees-admins" }], "name": "fees/editor" },
+        { "name": "fees/viewer", "granted_to": [{ "group": "fees-viewers" }] }
+      ],
+      "version": 3,
+      "service": "plugin-fees",
+      "permissions": [
+        { "roles": ["fees/editor"], "effect": "allow", "action": "create", "resource": "billing-packages" },
+        { "resource": "billing-packages", "action": "read", "effect": "allow", "roles": ["fees/editor", "fees/viewer"] },
+        { "resource": "billing-packages", "action": "delete", "effect": "deny", "roles": ["fees/viewer"] }
+      ]
+    }`
+
+	base, err := parseManifest([]byte(feesJSON))
+	require.NoError(t, err)
+
+	shuffled, err := parseManifest([]byte(reordered))
+	require.NoError(t, err)
+
+	hBase, err := base.CanonicalHash()
+	require.NoError(t, err)
+
+	hShuffled, err := shuffled.CanonicalHash()
+	require.NoError(t, err)
+
+	assert.Equal(t, hBase, hShuffled, "wire key ordering must not change the hash")
+}
+
+func TestCanonicalHash_ContentChangeChangesHash(t *testing.T) {
+	base, err := parseManifest([]byte(feesJSON))
+	require.NoError(t, err)
+
+	mutated := *base
+	perms := make([]DeclarationPermission, len(base.Permissions))
+	copy(perms, base.Permissions)
+	perms[0].Effect = "deny"
+	mutated.Permissions = perms
+
+	hBase, err := base.CanonicalHash()
+	require.NoError(t, err)
+
+	hMut, err := mutated.CanonicalHash()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, hBase, hMut, "any content change must change the hash")
+}
+
+func TestValidate_Valid(t *testing.T) {
+	m, err := parseManifest([]byte(feesJSON))
+	require.NoError(t, err)
+	require.NoError(t, m.Validate())
+}
+
+func TestValidate_RejectsBadManifests(t *testing.T) {
+	tests := map[string]string{
+		"empty service":   `{"version":1,"permissions":[{"resource":"r","action":"read","effect":"allow","roles":["x"]}],"roles":[{"name":"x"}]}`,
+		"zero version":    `{"service":"s","version":0,"roles":[{"name":"x"}],"permissions":[{"resource":"r","action":"read","effect":"allow","roles":["x"]}]}`,
+		"bad effect":      `{"service":"s","version":1,"roles":[{"name":"x"}],"permissions":[{"resource":"r","action":"read","effect":"maybe","roles":["x"]}]}`,
+		"undeclared role": `{"service":"s","version":1,"roles":[{"name":"x"}],"permissions":[{"resource":"r","action":"read","effect":"allow","roles":["ghost"]}]}`,
+		"perm no roles":   `{"service":"s","version":1,"roles":[{"name":"x"}],"permissions":[{"resource":"r","action":"read","effect":"allow"}]}`,
+		"empty resource":  `{"service":"s","version":1,"roles":[{"name":"x"}],"permissions":[{"resource":"","action":"read","effect":"allow","roles":["x"]}]}`,
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			m, err := parseManifest([]byte(raw))
+			require.NoError(t, err)
+
+			verr := m.Validate()
+			require.Error(t, verr, "expected validation to reject manifest")
+
+			var me *ManifestError
+			assert.ErrorAs(t, verr, &me, "validation error must be a *ManifestError")
+		})
+	}
+}

--- a/auth/declaration/publisher.go
+++ b/auth/declaration/publisher.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -346,9 +347,17 @@ func (p *Publisher) putWithRetry(ctx context.Context, token string) error {
 // either wrapped in backoff.Permanent (deterministic → stop) or plain (transient →
 // retry). nil means the declaration was accepted (200).
 func (p *Publisher) doPut(ctx context.Context, token string) error {
-	url := fmt.Sprintf("%s/v1/declarations/%s", p.identityAddr, p.slug)
+	// Build the URL from a parsed base so a trailing slash on IdentityAddr does not
+	// yield a "//v1" path, and JoinPath escapes the slug as a single path segment so
+	// a reserved char (e.g. '?') cannot alter the request target.
+	base, err := url.Parse(p.identityAddr)
+	if err != nil {
+		return backoff.Permanent(&PublishError{Deterministic: true, Op: "build request", Err: err})
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(p.wire))
+	reqURL := base.JoinPath("v1", "declarations", p.slug).String()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(p.wire))
 	if err != nil {
 		return backoff.Permanent(&PublishError{Deterministic: true, Op: "build request", Err: err})
 	}

--- a/auth/declaration/publisher.go
+++ b/auth/declaration/publisher.go
@@ -1,0 +1,492 @@
+// Package declaration is the "D7 declaration publisher": a startup hook that lets a
+// plugin publish its OWN permissions manifest to the access-manager (identity
+// component) at boot, instead of permissions living centrally in init_data.json.
+//
+// It runs ONCE at initialization (and, optionally, periodically) OUTSIDE the
+// request path — it is NOT per-request middleware. The plugin embeds its manifest
+// (//go:embed permissions.yaml) and this package mints an M2M token via the
+// existing middleware.AuthClient, then PUTs the wire JSON to
+// {IdentityAddr}/v1/declarations/{slug}.
+//
+// Correctness lives on the SERVER: the PUT is idempotent by hash (the identity
+// stores the manifest CanonicalHash on the M2M app and no-ops a matching PUT), so N
+// pods pushing the same manifest is safe by construction. Everything here (cache,
+// retry) is optimization/resilience, not a correctness requirement — which is why
+// every degraded path (no cache, identity down) is fail-open by default.
+//
+// Extension point (D10, deferred): manifest signing is out of scope. A future
+// cfg.Signer would compute an X-Declaration-Signature header over the wire JSON
+// here, before the PUT; the transport is untrusted by design (authority is the M2M
+// token + server-side BOLA), so signing is a BYOC/sovereign hardening, not a
+// correctness requirement.
+package declaration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	observability "github.com/LerianStudio/lib-observability/v2"
+	"github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/LerianStudio/lib-observability/v2/runtime"
+	"github.com/LerianStudio/lib-observability/v2/tracing"
+	"github.com/cenkalti/backoff/v5"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	// defaultMaxTries bounds the retry budget of a single Publish pass (one-shot
+	// mode). In periodic mode the next tick retries again, so the effective budget
+	// is unbounded across ticks — matching the spec (§6).
+	defaultMaxTries uint = 5
+
+	// defaultRetryInitialInterval / defaultRetryMaxInterval bound the exponential
+	// backoff (with jitter, via cenkalti/backoff/v5) between retries.
+	defaultRetryInitialInterval = 1 * time.Second
+	defaultRetryMaxInterval     = 30 * time.Second
+
+	// defaultCacheTTL is the advisory TTL for the cached hash. The final source of
+	// truth is the server-side `declaration-hash` Tag, so this is deliberately
+	// generous — it only trims redundant re-PUTs on the periodic path.
+	defaultCacheTTL = 24 * time.Hour
+
+	// spanName / componentName label observability signals.
+	spanName      = "declaration.publisher.publish"
+	componentName = "declaration"
+)
+
+// TokenMinter mints an M2M access token via client_credentials. Both lib-auth v2
+// and v3 *middleware.AuthClient satisfy it, so the publisher is not coupled to a
+// specific lib-auth major.
+type TokenMinter interface {
+	GetApplicationToken(ctx context.Context, clientID, clientSecret string) (string, error)
+}
+
+// Cache is the pluggable dedup seam — the SAME interface the future lib-auth
+// rate-limiter will consume. nil disables caching (the server no-ops by hash
+// anyway). An L1 in-memory default and an injected L2 Redis impl are follow-ups; the
+// pilot runs with Cache: nil.
+type Cache interface {
+	Get(ctx context.Context, key string) (string, bool)
+	Set(ctx context.Context, key, val string, ttl time.Duration)
+}
+
+// Config configures a Publisher.
+//
+// D10 (deferred): a future Signer field + X-Declaration-Signature header would live
+// here — see the package doc. Not implemented in the pilot.
+type Config struct {
+	// Slug is the service identifier. It MUST equal manifest.service and the M2M
+	// app DisplayName (the server enforces this via BOLA). Required.
+	Slug string
+	// Manifest is the embedded manifest content (permissions.yaml OR .json). The
+	// caller does the //go:embed (embed is relative to the caller's source). Required.
+	Manifest []byte
+	// IdentityAddr is the base URL of the identity component (target of the PUT).
+	// Distinct from the auth address; the plugin reads PLUGIN_IDENTITY_ADDRESS.
+	// Required.
+	IdentityAddr string
+	// Auth is any TokenMinter — typically the plugin's existing *middleware.AuthClient
+	// (v2 or v3). Its GetApplicationToken mints the M2M token (client_credentials);
+	// the concrete AuthClient also carries the AUTH address. Required.
+	Auth TokenMinter
+	// ClientID / ClientSecret are the plugin's M2M credentials (from manual
+	// provisioning). Required. ClientSecret is NEVER logged.
+	ClientID     string
+	ClientSecret string
+	// Cache is the optional, pluggable dedup cache. nil => always PUT (pilot).
+	Cache Cache
+	// Interval, when > 0, re-publishes periodically to heal drift. 0 = startup-only
+	// (pilot).
+	Interval time.Duration
+	// FailFast, when true, makes Start surface a failing initial publish as a fatal
+	// error. Default false (fail-open): the plugin serves regardless of the
+	// access-manager's availability.
+	FailFast bool
+	// Logger receives structured logs. Defaults to a no-op logger when nil.
+	Logger log.Logger
+}
+
+// Publisher publishes the plugin's permissions manifest to the access-manager at
+// startup. Construct it with New.
+type Publisher struct {
+	slug         string
+	identityAddr string
+	auth         TokenMinter
+	clientID     string
+	clientSecret string
+	cache        Cache
+	interval     time.Duration
+	failFast     bool
+	logger       log.Logger
+
+	// manifest is parsed+validated eagerly at New; wire and hash are precomputed so
+	// each Publish pass is a pure I/O operation.
+	manifest *DeclarationManifest
+	wire     []byte
+	hash     string
+
+	// retry knobs (exposed unexported for test overrides).
+	maxTries             uint
+	retryInitialInterval time.Duration
+	retryMaxInterval     time.Duration
+	cacheTTL             time.Duration
+
+	httpClient *http.Client
+}
+
+// PublishError is a typed publish failure. Deterministic errors (401/403/422, or
+// a misconfiguration) are NOT retried and NOT cached — they need human action.
+// Transient errors (409/5xx/network) are retried with backoff; after the budget is
+// exhausted the last transient error is returned (and the caller, if fail-open,
+// reschedules).
+type PublishError struct {
+	// StatusCode is the identity HTTP status (0 for a network/pre-request failure).
+	StatusCode int
+	// Deterministic classifies the error: true => no retry; false => transient.
+	Deterministic bool
+	// Op is the failing operation, for context (e.g. "put declaration").
+	Op string
+	// Detail is a safe, non-secret detail (e.g. the server message). Never a token.
+	Detail string
+	// Err is the wrapped cause, if any.
+	Err error
+}
+
+func (e *PublishError) Error() string {
+	kind := "transient"
+	if e.Deterministic {
+		kind = "deterministic"
+	}
+
+	msg := fmt.Sprintf("declaration publish failed (%s, op=%s", kind, e.Op)
+	if e.StatusCode != 0 {
+		msg += fmt.Sprintf(", status=%d", e.StatusCode)
+	}
+
+	if e.Detail != "" {
+		msg += fmt.Sprintf(", detail=%s", e.Detail)
+	}
+
+	msg += ")"
+
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+
+	return msg
+}
+
+func (e *PublishError) Unwrap() error { return e.Err }
+
+// New builds a Publisher. It validates the config and parses+validates the embedded
+// manifest eagerly, so a missing field or a broken manifest fails fast at boot
+// instead of at the first PUT. The hash and wire JSON are precomputed.
+func New(cfg Config) (*Publisher, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	manifest, err := parseManifest(cfg.Manifest)
+	if err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return nil, fmt.Errorf("validate manifest: %w", err)
+	}
+
+	if manifest.Service != cfg.Slug {
+		return nil, fmt.Errorf("slug %q must equal manifest.service %q (BOLA: DisplayName==slug==service)", cfg.Slug, manifest.Service)
+	}
+
+	wire, err := manifest.wireJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshal wire manifest: %w", err)
+	}
+
+	hash, err := manifest.CanonicalHash()
+	if err != nil {
+		return nil, fmt.Errorf("compute canonical hash: %w", err)
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.NewNop()
+	}
+
+	return &Publisher{
+		slug:                 cfg.Slug,
+		identityAddr:         cfg.IdentityAddr,
+		auth:                 cfg.Auth,
+		clientID:             cfg.ClientID,
+		clientSecret:         cfg.ClientSecret,
+		cache:                cfg.Cache,
+		interval:             cfg.Interval,
+		failFast:             cfg.FailFast,
+		logger:               logger,
+		manifest:             manifest,
+		wire:                 wire,
+		hash:                 hash,
+		maxTries:             defaultMaxTries,
+		retryInitialInterval: defaultRetryInitialInterval,
+		retryMaxInterval:     defaultRetryMaxInterval,
+		cacheTTL:             defaultCacheTTL,
+		httpClient:           &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+func validateConfig(cfg Config) error {
+	switch {
+	case cfg.Slug == "":
+		return errors.New("config: Slug is required")
+	case len(cfg.Manifest) == 0:
+		return errors.New("config: Manifest is required")
+	case cfg.IdentityAddr == "":
+		return errors.New("config: IdentityAddr is required")
+	case cfg.Auth == nil:
+		return errors.New("config: Auth is required")
+	case cfg.ClientID == "":
+		return errors.New("config: ClientID is required")
+	case cfg.ClientSecret == "":
+		return errors.New("config: ClientSecret is required")
+	default:
+		return nil
+	}
+}
+
+// cacheKey is the dedup key for the slug's hash.
+func (p *Publisher) cacheKey() string {
+	return "declaration:" + p.slug + ":hash"
+}
+
+// Publish executes ONE pass of the flow (§4): cache check → mint token → PUT →
+// store hash. It is idempotent (the server no-ops a matching hash) and, on failure,
+// returns a typed *PublishError; the caller decides whether that is fatal.
+func (p *Publisher) Publish(ctx context.Context) error {
+	_, tracer, reqID, _ := observability.NewTrackingFromContext(ctx)
+
+	ctx, span := tracer.Start(ctx, spanName)
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("app.request.request_id", reqID),
+		attribute.String("declaration.slug", p.slug),
+		attribute.String("declaration.hash", p.hash),
+	)
+
+	if p.cache != nil {
+		if cached, ok := p.cache.Get(ctx, p.cacheKey()); ok && cached == p.hash {
+			p.logInfof(ctx, "declaration already published for slug=%s (hash match), skipping PUT", p.slug)
+
+			return nil
+		}
+	}
+
+	token, err := p.auth.GetApplicationToken(ctx, p.clientID, p.clientSecret)
+	if err != nil {
+		pubErr := &PublishError{Deterministic: false, Op: "mint m2m token", Err: err}
+		p.logWarnf(ctx, "failed to mint M2M token for slug=%s (transient, will retry): %v", p.slug, err)
+		tracing.HandleSpanError(span, "mint m2m token failed", pubErr)
+
+		return pubErr
+	}
+
+	if token == "" {
+		p.logErrorf(ctx, "empty M2M token for slug=%s (auth disabled or misconfigured); not retrying", p.slug)
+
+		pubErr := &PublishError{Deterministic: true, Op: "mint m2m token", Detail: "empty token (auth disabled or misconfigured)"}
+		tracing.HandleSpanError(span, "empty m2m token", pubErr)
+
+		return pubErr
+	}
+
+	if err := p.putWithRetry(ctx, token); err != nil {
+		tracing.HandleSpanError(span, "put declaration failed", err)
+
+		return err
+	}
+
+	if p.cache != nil {
+		p.cache.Set(ctx, p.cacheKey(), p.hash, p.cacheTTL)
+	}
+
+	p.logInfof(ctx, "declaration published for slug=%s (hash=%s)", p.slug, p.hash)
+
+	return nil
+}
+
+// putWithRetry issues the PUT under exponential backoff (with jitter). Deterministic
+// failures short-circuit via backoff.Permanent; transient failures retry until the
+// budget is exhausted, then surface the last error.
+func (p *Publisher) putWithRetry(ctx context.Context, token string) error {
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = p.retryInitialInterval
+	exp.MaxInterval = p.retryMaxInterval
+
+	op := func() (struct{}, error) {
+		return struct{}{}, p.doPut(ctx, token)
+	}
+
+	_, err := backoff.Retry(ctx, op,
+		backoff.WithBackOff(exp),
+		backoff.WithMaxTries(p.maxTries),
+	)
+
+	return err
+}
+
+// doPut performs one PUT and classifies the result per §8. A returned error is
+// either wrapped in backoff.Permanent (deterministic → stop) or plain (transient →
+// retry). nil means the declaration was accepted (200).
+func (p *Publisher) doPut(ctx context.Context, token string) error {
+	url := fmt.Sprintf("%s/v1/declarations/%s", p.identityAddr, p.slug)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(p.wire))
+	if err != nil {
+		return backoff.Permanent(&PublishError{Deterministic: true, Op: "build request", Err: err})
+	}
+
+	tracing.InjectHTTPContext(ctx, req.Header)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		p.logWarnf(ctx, "declaration PUT network error for slug=%s (transient, will retry): %v", p.slug, err)
+
+		return &PublishError{Deterministic: false, Op: "put declaration", Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	detail := serverMessage(body)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusUnprocessableEntity:
+		pubErr := &PublishError{Deterministic: true, StatusCode: resp.StatusCode, Op: "put declaration", Detail: detail}
+		p.logErrorf(ctx, "declaration PUT rejected for slug=%s: status=%d detail=%q (deterministic, not retrying)", p.slug, resp.StatusCode, detail)
+
+		return backoff.Permanent(pubErr)
+	default:
+		pubErr := &PublishError{Deterministic: false, StatusCode: resp.StatusCode, Op: "put declaration", Detail: detail}
+		p.logWarnf(ctx, "declaration PUT failed for slug=%s: status=%d detail=%q (transient, will retry)", p.slug, resp.StatusCode, detail)
+
+		return pubErr
+	}
+}
+
+// Start runs Publish in the background so it never blocks serving, and — when
+// Interval > 0 — re-publishes on a ticker to heal drift. It returns a stop func for
+// graceful shutdown.
+//
+// Fail-open (default): a failing initial Publish does NOT make Start return a fatal
+// error; it is logged and (if periodic) retried on the next tick. With FailFast the
+// initial Publish runs synchronously and its error surfaces from Start.
+func (p *Publisher) Start(ctx context.Context) (func(), error) {
+	runCtx, cancel := context.WithCancel(ctx)
+
+	if p.failFast {
+		if err := p.Publish(runCtx); err != nil {
+			cancel()
+
+			return func() {}, fmt.Errorf("initial declaration publish failed (fail-fast): %w", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer runtime.RecoverAndLogWithContext(runCtx, p.logger, componentName, "publisher.loop")
+
+		p.runLoop(runCtx)
+	}()
+
+	stop := func() {
+		cancel()
+		wg.Wait()
+	}
+
+	return stop, nil
+}
+
+// runLoop performs the initial publish (unless already done in fail-fast mode) then,
+// if configured, re-publishes on the ticker until the context is cancelled.
+func (p *Publisher) runLoop(ctx context.Context) {
+	if !p.failFast {
+		if err := p.Publish(ctx); err != nil {
+			p.logWarnf(ctx, "initial declaration publish failed for slug=%s (fail-open, serving continues): %v", p.slug, err)
+		}
+	}
+
+	if p.interval <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := p.Publish(ctx); err != nil {
+				p.logWarnf(ctx, "periodic declaration publish failed for slug=%s (will retry next tick): %v", p.slug, err)
+			}
+		}
+	}
+}
+
+// serverMessage extracts a safe, human-readable detail from the identity error
+// body (the server message is not secret). It tolerates a non-JSON body.
+func serverMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	var parsed struct {
+		Message string `json:"message"`
+		Title   string `json:"title"`
+	}
+
+	if err := json.Unmarshal(body, &parsed); err == nil {
+		if parsed.Message != "" {
+			return parsed.Message
+		}
+
+		if parsed.Title != "" {
+			return parsed.Title
+		}
+	}
+
+	const maxLen = 256
+	if len(body) > maxLen {
+		return string(body[:maxLen])
+	}
+
+	return string(body)
+}
+
+func (p *Publisher) logInfof(ctx context.Context, format string, args ...any) {
+	p.logger.Log(ctx, log.LevelInfo, fmt.Sprintf(format, args...))
+}
+
+func (p *Publisher) logWarnf(ctx context.Context, format string, args ...any) {
+	p.logger.Log(ctx, log.LevelWarn, fmt.Sprintf(format, args...))
+}
+
+func (p *Publisher) logErrorf(ctx context.Context, format string, args ...any) {
+	p.logger.Log(ctx, log.LevelError, fmt.Sprintf(format, args...))
+}

--- a/auth/declaration/publisher.go
+++ b/auth/declaration/publisher.go
@@ -290,26 +290,8 @@ func (p *Publisher) Publish(ctx context.Context) error {
 		}
 	}
 
-	token, err := p.auth.GetApplicationToken(ctx, p.clientID, p.clientSecret)
-	if err != nil {
-		pubErr := &PublishError{Deterministic: false, Op: "mint m2m token", Err: err}
-		p.logWarnf(ctx, "failed to mint M2M token for slug=%s (transient, will retry): %v", p.slug, err)
-		tracing.HandleSpanError(span, "mint m2m token failed", pubErr)
-
-		return pubErr
-	}
-
-	if token == "" {
-		p.logErrorf(ctx, "empty M2M token for slug=%s (auth disabled or misconfigured); not retrying", p.slug)
-
-		pubErr := &PublishError{Deterministic: true, Op: "mint m2m token", Detail: "empty token (auth disabled or misconfigured)"}
-		tracing.HandleSpanError(span, "empty m2m token", pubErr)
-
-		return pubErr
-	}
-
-	if err := p.putWithRetry(ctx, token); err != nil {
-		tracing.HandleSpanError(span, "put declaration failed", err)
+	if err := p.mintAndPutWithRetry(ctx); err != nil {
+		tracing.HandleSpanError(span, "publish declaration failed", err)
 
 		return err
 	}
@@ -323,15 +305,35 @@ func (p *Publisher) Publish(ctx context.Context) error {
 	return nil
 }
 
-// putWithRetry issues the PUT under exponential backoff (with jitter). Deterministic
-// failures short-circuit via backoff.Permanent; transient failures retry until the
-// budget is exhausted, then surface the last error.
-func (p *Publisher) putWithRetry(ctx context.Context, token string) error {
+// mintAndPutWithRetry runs mint→PUT as a SINGLE bounded backoff operation, minting a
+// FRESH token per attempt so a transient auth outage at boot is retried alongside the
+// PUT (not fatal for the whole one-shot pass). Classification is preserved: a
+// transient mint error is a plain error (retried); an empty token (auth
+// disabled/misconfigured) is backoff.Permanent (deterministic, not retried); doPut's
+// own deterministic/transient classification is unchanged. Transient failures retry
+// until the budget is exhausted, then surface the last error.
+func (p *Publisher) mintAndPutWithRetry(ctx context.Context) error {
 	exp := backoff.NewExponentialBackOff()
 	exp.InitialInterval = p.retryInitialInterval
 	exp.MaxInterval = p.retryMaxInterval
 
 	op := func() (struct{}, error) {
+		token, err := p.auth.GetApplicationToken(ctx, p.clientID, p.clientSecret)
+		if err != nil {
+			pubErr := &PublishError{Deterministic: false, Op: "mint m2m token", Err: err}
+			p.logWarnf(ctx, "failed to mint M2M token for slug=%s (transient, will retry): %v", p.slug, err)
+
+			return struct{}{}, pubErr
+		}
+
+		if token == "" {
+			p.logErrorf(ctx, "empty M2M token for slug=%s (auth disabled or misconfigured); not retrying", p.slug)
+
+			pubErr := &PublishError{Deterministic: true, Op: "mint m2m token", Detail: "empty token (auth disabled or misconfigured)"}
+
+			return struct{}{}, backoff.Permanent(pubErr)
+		}
+
 		return struct{}{}, p.doPut(ctx, token)
 	}
 
@@ -348,14 +350,26 @@ func (p *Publisher) putWithRetry(ctx context.Context, token string) error {
 // retry). nil means the declaration was accepted (200).
 func (p *Publisher) doPut(ctx context.Context, token string) error {
 	// Build the URL from a parsed base so a trailing slash on IdentityAddr does not
-	// yield a "//v1" path, and JoinPath escapes the slug as a single path segment so
-	// a reserved char (e.g. '?') cannot alter the request target.
+	// yield a "//v1" path. JoinPath is used only for the STATIC prefix; the slug is
+	// appended as a single, fully percent-escaped path segment via RawPath so a
+	// reserved char (e.g. '?') or a literal '/' cannot add a segment or alter the
+	// request target. Note: passing url.PathEscape(slug) into JoinPath would
+	// double-escape (JoinPath re-escapes the '%'), hence the explicit Path/RawPath.
 	base, err := url.Parse(p.identityAddr)
 	if err != nil {
 		return backoff.Permanent(&PublishError{Deterministic: true, Op: "build request", Err: err})
 	}
 
-	reqURL := base.JoinPath("v1", "declarations", p.slug).String()
+	base = base.JoinPath("v1", "declarations")
+
+	// escapedPrefix is the escaped static prefix (e.g. "/v1/declarations"); compute it
+	// BEFORE mutating Path. Path holds the decoded form; RawPath holds the escaped form
+	// so URL.String() emits "<prefix>/<escaped-slug>" and round-trips unchanged.
+	escapedPrefix := base.EscapedPath()
+	base.Path += "/" + p.slug
+	base.RawPath = escapedPrefix + "/" + url.PathEscape(p.slug)
+
+	reqURL := base.String()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(p.wire))
 	if err != nil {

--- a/auth/declaration/publisher.go
+++ b/auth/declaration/publisher.go
@@ -257,9 +257,22 @@ func validateConfig(cfg Config) error {
 		return errors.New("config: ClientID is required")
 	case cfg.ClientSecret == "":
 		return errors.New("config: ClientSecret is required")
-	default:
-		return nil
 	}
+
+	// IdentityAddr must be an absolute http(s) URL: parse cleanly, carry an http or
+	// https scheme, and a non-empty host. A hostless or wrong-scheme value would
+	// otherwise pass here and only fail later inside doPut as a *retryable* PUT
+	// error, masking a boot-time misconfiguration.
+	u, err := url.Parse(cfg.IdentityAddr)
+	if err != nil {
+		return fmt.Errorf("config: IdentityAddr is not a valid URL: %w", err)
+	}
+
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("config: IdentityAddr must be an absolute http(s) URL, got %q", cfg.IdentityAddr)
+	}
+
+	return nil
 }
 
 // cacheKey is the dedup key for the slug's hash.

--- a/auth/declaration/publisher_test.go
+++ b/auth/declaration/publisher_test.go
@@ -471,6 +471,34 @@ func TestPublish_SlugWithReservedChar_EscapedSingleSegment(t *testing.T) {
 		"a reserved char in the slug must not leak into the request query string")
 }
 
+// TestPublish_SlugWithSlash_EscapedSingleSegment asserts that a literal '/' in the
+// slug is percent-escaped into a SINGLE path segment (a%2Fb) rather than being
+// treated as a path separator (which would mis-route the PUT to an extra segment).
+func TestPublish_SlugWithSlash_EscapedSingleSegment(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	// New enforces slug == manifest.service, so the '/' is driven through a manifest
+	// whose service carries it. Production validation is NOT weakened.
+	cfg := testConfig(t, auth.URL, identity.URL)
+	cfg.Slug = "a/b"
+	cfg.Manifest = []byte(`{"service":"a/b","version":1}`)
+	p := newFastPublisher(t, cfg)
+
+	require.NoError(t, p.Publish(context.Background()))
+	assert.Equal(t, 1, identity.count())
+
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	assert.Equal(t, "/v1/declarations/a%2Fb", identity.gotPath,
+		"a literal '/' in the slug must be percent-escaped into a SINGLE path segment")
+	assert.Empty(t, identity.gotRawQuery,
+		"the slug must not leak into the request query string")
+}
+
 func TestPublish_NeverLogsSecretOrToken(t *testing.T) {
 	auth := newAuthServer(t)
 	t.Cleanup(auth.Close)

--- a/auth/declaration/publisher_test.go
+++ b/auth/declaration/publisher_test.go
@@ -3,6 +3,7 @@ package declaration
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -41,13 +42,15 @@ func newAuthServer(t *testing.T) *httptest.Server {
 // identityServer stands in for the IDENTITY host: PUT /v1/declarations/{slug}.
 type identityServer struct {
 	*httptest.Server
-	mu       sync.Mutex
-	putCount int
-	status   int
-	body     string
-	gotAuth  string
-	gotBody  string
-	puts     chan struct{}
+	mu          sync.Mutex
+	putCount    int
+	status      int
+	body        string
+	gotAuth     string
+	gotBody     string
+	gotPath     string
+	gotRawQuery string
+	puts        chan struct{}
 }
 
 func newIdentityServer(t *testing.T, status int, body string) *identityServer {
@@ -55,13 +58,25 @@ func newIdentityServer(t *testing.T, status int, body string) *identityServer {
 
 	is := &identityServer{status: status, body: body, puts: make(chan struct{}, 16)}
 	is.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the request-target (escaped path + raw query) before any
+		// routing check so URL-construction assertions can see a mis-routed target.
+		is.mu.Lock()
+		is.gotPath = r.URL.EscapedPath()
+		is.gotRawQuery = r.URL.RawQuery
+		is.mu.Unlock()
+
 		if r.Method != http.MethodPut || !strings.HasPrefix(r.URL.Path, "/v1/declarations/") {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 
-		buf := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(buf)
+		// Read the FULL body: a single Read may return a partial payload, which
+		// would let wire-format assertions pass on a truncated request.
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
+		}
 
 		is.mu.Lock()
 		is.putCount++
@@ -403,6 +418,57 @@ func TestStart_Success(t *testing.T) {
 
 	stop()
 	assert.GreaterOrEqual(t, identity.count(), 1)
+}
+
+// TestPublish_IdentityAddrTrailingSlash_NoDoubleSlash asserts that a trailing
+// slash on IdentityAddr (a common env-var footgun on PLUGIN_IDENTITY_HOST) does
+// NOT produce a "//v1" request target — the base slash must be normalized.
+func TestPublish_IdentityAddrTrailingSlash_NoDoubleSlash(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	// Trailing slash on the base URL.
+	cfg := testConfig(t, auth.URL, identity.URL+"/")
+	p := newFastPublisher(t, cfg)
+
+	require.NoError(t, p.Publish(context.Background()))
+	assert.Equal(t, 1, identity.count())
+
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	assert.Equal(t, "/v1/declarations/plugin-fees", identity.gotPath,
+		"a trailing slash on IdentityAddr must not yield a double slash in the request path")
+}
+
+// TestPublish_SlugWithReservedChar_EscapedSingleSegment asserts that a slug
+// carrying a reserved character is percent-escaped into a SINGLE path segment and
+// does not leak into the query string (which naive fmt.Sprintf construction allows).
+func TestPublish_SlugWithReservedChar_EscapedSingleSegment(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	// New enforces slug == manifest.service, so the reserved char is driven through
+	// a manifest whose service carries it. Production validation is NOT weakened.
+	cfg := testConfig(t, auth.URL, identity.URL)
+	cfg.Slug = "a?b"
+	cfg.Manifest = []byte(`{"service":"a?b","version":1}`)
+	p := newFastPublisher(t, cfg)
+
+	require.NoError(t, p.Publish(context.Background()))
+	assert.Equal(t, 1, identity.count())
+
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	assert.Equal(t, "/v1/declarations/a%3Fb", identity.gotPath,
+		"a reserved char in the slug must be percent-escaped as a single path segment")
+	assert.Empty(t, identity.gotRawQuery,
+		"a reserved char in the slug must not leak into the request query string")
 }
 
 func TestPublish_NeverLogsSecretOrToken(t *testing.T) {

--- a/auth/declaration/publisher_test.go
+++ b/auth/declaration/publisher_test.go
@@ -1,0 +1,426 @@
+package declaration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	liblog "github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testClientID     = "f4adb14-test-client-id"
+	testClientSecret = "super-secret-value-do-not-log"
+	testToken        = "test-access-token-do-not-log"
+)
+
+// authServer stands in for the AUTH host: health + M2M token mint.
+func newAuthServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v1/login/oauth/access_token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"accessToken":%q}`, testToken)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// identityServer stands in for the IDENTITY host: PUT /v1/declarations/{slug}.
+type identityServer struct {
+	*httptest.Server
+	mu       sync.Mutex
+	putCount int
+	status   int
+	body     string
+	gotAuth  string
+	gotBody  string
+	puts     chan struct{}
+}
+
+func newIdentityServer(t *testing.T, status int, body string) *identityServer {
+	t.Helper()
+
+	is := &identityServer{status: status, body: body, puts: make(chan struct{}, 16)}
+	is.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || !strings.HasPrefix(r.URL.Path, "/v1/declarations/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+
+		is.mu.Lock()
+		is.putCount++
+		is.gotAuth = r.Header.Get("Authorization")
+		is.gotBody = string(buf)
+		st := is.status
+		bd := is.body
+		is.mu.Unlock()
+
+		select {
+		case is.puts <- struct{}{}:
+		default:
+		}
+
+		w.WriteHeader(st)
+		_, _ = w.Write([]byte(bd))
+	}))
+
+	return is
+}
+
+func (is *identityServer) count() int {
+	is.mu.Lock()
+	defer is.mu.Unlock()
+
+	return is.putCount
+}
+
+// captureLogger records every message so tests can assert secrets never leak.
+type captureLogger struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (c *captureLogger) Log(_ context.Context, _ liblog.Level, msg string, fields ...liblog.Field) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.msgs = append(c.msgs, msg)
+}
+func (c *captureLogger) With(_ ...liblog.Field) liblog.Logger { return c }
+func (c *captureLogger) WithGroup(_ string) liblog.Logger     { return c }
+func (c *captureLogger) Enabled(_ liblog.Level) bool          { return true }
+func (c *captureLogger) Sync(_ context.Context) error         { return nil }
+
+func (c *captureLogger) all() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return strings.Join(c.msgs, "\n")
+}
+
+// fakeCache is a map-backed test double for the pluggable Cache seam.
+type fakeCache struct {
+	mu sync.Mutex
+	m  map[string]string
+}
+
+func newFakeCache() *fakeCache { return &fakeCache{m: map[string]string{}} }
+
+func (c *fakeCache) Get(_ context.Context, key string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	v, ok := c.m[key]
+
+	return v, ok
+}
+
+func (c *fakeCache) Set(_ context.Context, key, val string, _ time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.m[key] = val
+}
+
+func (c *fakeCache) get(key string) (string, bool) { return c.Get(context.Background(), key) }
+
+// testConfig builds a valid Config wired to the given auth+identity servers.
+func testConfig(t *testing.T, authURL, identityURL string) Config {
+	t.Helper()
+
+	l := liblog.NewNop()
+	auth := middleware.NewAuthClient(authURL, true, &l)
+
+	return Config{
+		Slug:         "plugin-fees",
+		Manifest:     []byte(feesJSON),
+		IdentityAddr: identityURL,
+		Auth:         auth,
+		ClientID:     testClientID,
+		ClientSecret: testClientSecret,
+	}
+}
+
+// newFastPublisher builds a Publisher with tiny retry timings for fast tests.
+func newFastPublisher(t *testing.T, cfg Config) *Publisher {
+	t.Helper()
+
+	p, err := New(cfg)
+	require.NoError(t, err)
+
+	p.retryInitialInterval = time.Millisecond
+	p.retryMaxInterval = 2 * time.Millisecond
+	p.maxTries = 3
+
+	return p
+}
+
+func TestNew_Validation(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	base := testConfig(t, auth.URL, "http://identity.local")
+
+	t.Run("valid", func(t *testing.T) {
+		p, err := New(base)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		assert.NotNil(t, p.logger, "logger must default to a no-op when nil")
+	})
+
+	mutations := map[string]func(c *Config){
+		"missing slug":          func(c *Config) { c.Slug = "" },
+		"missing manifest":      func(c *Config) { c.Manifest = nil },
+		"missing identity addr": func(c *Config) { c.IdentityAddr = "" },
+		"missing auth":          func(c *Config) { c.Auth = nil },
+		"missing client id":     func(c *Config) { c.ClientID = "" },
+		"missing client secret": func(c *Config) { c.ClientSecret = "" },
+		"bad manifest":          func(c *Config) { c.Manifest = []byte("{ not json") },
+		"slug != service":       func(c *Config) { c.Slug = "mismatch" },
+		"invalid manifest":      func(c *Config) { c.Manifest = []byte(`{"service":"plugin-fees","version":0}`) },
+	}
+
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			cfg := base
+			mutate(&cfg)
+
+			_, err := New(cfg)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestPublish_Success_CacheNil_AlwaysPUTs(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	p := newFastPublisher(t, testConfig(t, auth.URL, identity.URL))
+
+	require.NoError(t, p.Publish(context.Background()))
+	assert.Equal(t, 1, identity.count())
+
+	// Authorization header carries the minted token; body is the wire JSON.
+	identity.mu.Lock()
+	defer identity.mu.Unlock()
+	assert.Equal(t, "Bearer "+testToken, identity.gotAuth)
+	assert.Contains(t, identity.gotBody, `"service":"plugin-fees"`)
+}
+
+func TestPublish_Success_StoresHash(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	cache := newFakeCache()
+	cfg := testConfig(t, auth.URL, identity.URL)
+	cfg.Cache = cache
+	p := newFastPublisher(t, cfg)
+
+	require.NoError(t, p.Publish(context.Background()))
+	assert.Equal(t, 1, identity.count())
+
+	stored, ok := cache.get("declaration:plugin-fees:hash")
+	require.True(t, ok, "hash must be stored after a 200")
+	assert.Equal(t, p.hash, stored)
+}
+
+func TestPublish_CacheHit_SkipsPUT(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	cache := newFakeCache()
+	cfg := testConfig(t, auth.URL, identity.URL)
+	cfg.Cache = cache
+	p := newFastPublisher(t, cfg)
+
+	// Pre-seed the cache with the computed hash → publish must skip the PUT.
+	cache.Set(context.Background(), "declaration:plugin-fees:hash", p.hash, time.Hour)
+
+	require.NoError(t, p.Publish(context.Background()))
+	assert.Equal(t, 0, identity.count(), "cache hit must skip the PUT")
+}
+
+func TestPublish_Deterministic_NoRetry(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusUnprocessableEntity} {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			auth := newAuthServer(t)
+			t.Cleanup(auth.Close)
+
+			identity := newIdentityServer(t, status, `{"message":"nope"}`)
+			t.Cleanup(identity.Close)
+
+			cache := newFakeCache()
+			cfg := testConfig(t, auth.URL, identity.URL)
+			cfg.Cache = cache
+			p := newFastPublisher(t, cfg)
+
+			err := p.Publish(context.Background())
+			require.Error(t, err)
+
+			var pe *PublishError
+			require.ErrorAs(t, err, &pe)
+			assert.True(t, pe.Deterministic, "status %d must be deterministic", status)
+			assert.Equal(t, status, pe.StatusCode)
+			assert.Equal(t, 1, identity.count(), "deterministic error must NOT retry")
+
+			_, ok := cache.get("declaration:plugin-fees:hash")
+			assert.False(t, ok, "deterministic failure must not write the cache")
+		})
+	}
+}
+
+func TestPublish_Transient_RetriesThenGivesUp(t *testing.T) {
+	for _, status := range []int{http.StatusConflict, http.StatusInternalServerError, http.StatusBadGateway} {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			auth := newAuthServer(t)
+			t.Cleanup(auth.Close)
+
+			identity := newIdentityServer(t, status, `{"message":"later"}`)
+			t.Cleanup(identity.Close)
+
+			cache := newFakeCache()
+			cfg := testConfig(t, auth.URL, identity.URL)
+			cfg.Cache = cache
+			p := newFastPublisher(t, cfg)
+
+			err := p.Publish(context.Background())
+			require.Error(t, err)
+
+			var pe *PublishError
+			require.ErrorAs(t, err, &pe)
+			assert.False(t, pe.Deterministic, "status %d must be transient", status)
+			assert.Equal(t, int(p.maxTries), identity.count(), "transient error must retry maxTries times")
+
+			_, ok := cache.get("declaration:plugin-fees:hash")
+			assert.False(t, ok, "transient failure must not write the cache")
+		})
+	}
+}
+
+func TestPublish_NetworkError_Transient(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, "{}")
+	down := identity.URL
+	identity.Close() // connection refused → network/transient
+
+	cfg := testConfig(t, auth.URL, down)
+	p := newFastPublisher(t, cfg)
+
+	err := p.Publish(context.Background())
+	require.Error(t, err)
+
+	var pe *PublishError
+	require.ErrorAs(t, err, &pe)
+	assert.False(t, pe.Deterministic, "network failure must be transient")
+}
+
+func TestStart_FailOpen_5xx_NoFatal(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusInternalServerError, `{"message":"down"}`)
+	t.Cleanup(identity.Close)
+
+	p := newFastPublisher(t, testConfig(t, auth.URL, identity.URL))
+
+	stop, err := p.Start(context.Background())
+	require.NoError(t, err, "fail-open: a failing initial publish must NOT fatal Start")
+	require.NotNil(t, stop)
+
+	// A publish attempt was still made in the background.
+	select {
+	case <-identity.puts:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a background publish attempt")
+	}
+
+	stop()
+}
+
+func TestStart_FailFast_SurfacesError(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusInternalServerError, `{"message":"down"}`)
+	t.Cleanup(identity.Close)
+
+	cfg := testConfig(t, auth.URL, identity.URL)
+	cfg.FailFast = true
+	p := newFastPublisher(t, cfg)
+
+	stop, err := p.Start(context.Background())
+	require.Error(t, err, "fail-fast: initial publish failure must surface")
+
+	if stop != nil {
+		stop()
+	}
+}
+
+func TestStart_Success(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	p := newFastPublisher(t, testConfig(t, auth.URL, identity.URL))
+
+	stop, err := p.Start(context.Background())
+	require.NoError(t, err)
+
+	select {
+	case <-identity.puts:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a background publish")
+	}
+
+	stop()
+	assert.GreaterOrEqual(t, identity.count(), 1)
+}
+
+func TestPublish_NeverLogsSecretOrToken(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	// 401 to exercise the error-logging path too.
+	identity := newIdentityServer(t, http.StatusUnauthorized, `{"message":"bad"}`)
+	t.Cleanup(identity.Close)
+
+	cap := &captureLogger{}
+	cfg := testConfig(t, auth.URL, identity.URL)
+	cfg.Logger = cap
+	p := newFastPublisher(t, cfg)
+
+	_ = p.Publish(context.Background())
+
+	logs := cap.all()
+	assert.NotContains(t, logs, testClientSecret, "client secret must never be logged")
+	assert.NotContains(t, logs, testToken, "minted token must never be logged")
+}

--- a/auth/declaration/publisher_test.go
+++ b/auth/declaration/publisher_test.go
@@ -222,6 +222,43 @@ func TestNew_Validation(t *testing.T) {
 	}
 }
 
+// TestNew_RejectsInvalidIdentityAddr asserts New rejects an IdentityAddr that is
+// not an absolute http(s) URL (empty, scheme-less, wrong scheme, or hostless) at
+// construction, instead of letting it masquerade as a retryable PUT failure, and
+// accepts well-formed http/https base URLs.
+func TestNew_RejectsInvalidIdentityAddr(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	rejected := map[string]string{
+		"empty":        "",
+		"no scheme":    "identity-host:4001",
+		"wrong scheme": "ftp://host",
+		"no host":      "http://",
+	}
+	for name, addr := range rejected {
+		t.Run("reject/"+name, func(t *testing.T) {
+			cfg := testConfig(t, auth.URL, addr)
+
+			_, err := New(cfg)
+			require.Error(t, err, "IdentityAddr %q must be rejected at construction", addr)
+		})
+	}
+
+	accepted := map[string]string{
+		"http localhost": "http://localhost:4001",
+		"https host":     "https://identity.example.com",
+	}
+	for name, addr := range accepted {
+		t.Run("accept/"+name, func(t *testing.T) {
+			cfg := testConfig(t, auth.URL, addr)
+
+			_, err := New(cfg)
+			require.NoError(t, err, "IdentityAddr %q must be accepted", addr)
+		})
+	}
+}
+
 func TestPublish_Success_CacheNil_AlwaysPUTs(t *testing.T) {
 	auth := newAuthServer(t)
 	t.Cleanup(auth.Close)

--- a/auth/declaration/token_minter_test.go
+++ b/auth/declaration/token_minter_test.go
@@ -32,6 +32,25 @@ func (f *fakeMinter) GetApplicationToken(_ context.Context, _, _ string) (string
 	return f.token, f.err
 }
 
+// flakyMinter is a TokenMinter test double that errors on its first failFor calls
+// and then returns token — modelling a transient auth outage at boot that recovers
+// within the retry budget.
+type flakyMinter struct {
+	failFor int
+	token   string
+	calls   int
+}
+
+func (f *flakyMinter) GetApplicationToken(_ context.Context, _, _ string) (string, error) {
+	f.calls++
+
+	if f.calls <= f.failFor {
+		return "", errors.New("transient auth outage")
+	}
+
+	return f.token, nil
+}
+
 // TestConfigAuth_AcceptsRealAuthClient proves the concrete v3 *middleware.AuthClient
 // still satisfies Config.Auth (now typed as TokenMinter) end-to-end: it mints against
 // a real httptest AUTH server and the publish succeeds against a real identity server.
@@ -57,8 +76,9 @@ func TestConfigAuth_AcceptsRealAuthClient(t *testing.T) {
 }
 
 // TestPublish_MintFailure_Transient_WithFakeMinter exercises the mint-failure path
-// through the TokenMinter seam (no HTTP), asserting it is classified transient and
-// never reaches the identity server.
+// through the TokenMinter seam (no HTTP), asserting it is classified transient,
+// retried across the full budget (mint is now inside the bounded backoff), and never
+// reaches the identity server.
 func TestPublish_MintFailure_Transient_WithFakeMinter(t *testing.T) {
 	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
 	t.Cleanup(identity.Close)
@@ -81,7 +101,7 @@ func TestPublish_MintFailure_Transient_WithFakeMinter(t *testing.T) {
 	require.ErrorAs(t, err, &pe)
 	assert.False(t, pe.Deterministic, "mint failure must be transient")
 	assert.Equal(t, "mint m2m token", pe.Op)
-	assert.Equal(t, 1, fm.calls, "the minter must have been called exactly once")
+	assert.Equal(t, int(p.maxTries), fm.calls, "a transient mint failure must be retried across the full budget")
 	assert.Equal(t, 0, identity.count(), "a mint failure must never reach the identity server")
 }
 
@@ -108,5 +128,34 @@ func TestPublish_EmptyToken_Deterministic_WithFakeMinter(t *testing.T) {
 	var pe *PublishError
 	require.ErrorAs(t, err, &pe)
 	assert.True(t, pe.Deterministic, "empty token must be deterministic (no retry)")
+	assert.Equal(t, 1, fm.calls, "an empty (deterministic) token must be minted exactly once — no retry")
 	assert.Equal(t, 0, identity.count(), "an empty token must never reach the identity server")
+}
+
+// TestPublish_TransientMint_RetriesThenSucceeds proves a TRANSIENT mint failure at
+// boot is retried inside the bounded backoff and, once the mint recovers within the
+// budget, the PUT still happens and Publish returns nil. (Regression for the bug
+// where the mint sat OUTSIDE the retry loop, so a single boot-time auth blip meant
+// the declaration was never published until a pod restart.)
+func TestPublish_TransientMint_RetriesThenSucceeds(t *testing.T) {
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	// Fail the first two mint attempts, then succeed — within the maxTries=3 budget.
+	fm := &flakyMinter{failFor: 2, token: testToken}
+	cfg := Config{
+		Slug:         "plugin-fees",
+		Manifest:     []byte(feesJSON),
+		IdentityAddr: identity.URL,
+		Auth:         fm,
+		ClientID:     testClientID,
+		ClientSecret: testClientSecret,
+	}
+	p := newFastPublisher(t, cfg) // maxTries = 3
+
+	require.NoError(t, p.Publish(context.Background()),
+		"a transient mint failure must be retried within the budget and then succeed")
+	assert.Equal(t, 3, fm.calls, "the mint must be retried per attempt (2 failures + 1 success)")
+	assert.Equal(t, 1, identity.count(), "the PUT must happen once the mint eventually succeeds")
+	assert.Equal(t, "Bearer "+testToken, identity.gotAuth)
 }

--- a/auth/declaration/token_minter_test.go
+++ b/auth/declaration/token_minter_test.go
@@ -1,0 +1,112 @@
+package declaration
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/LerianStudio/lib-auth/v3/auth/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time contract lock: the real v3 *middleware.AuthClient MUST satisfy
+// TokenMinter. This is the whole point of the interface — the publisher must not
+// be coupled to a specific lib-auth major, and both v2 and v3 AuthClient expose an
+// identical GetApplicationToken signature. If this stops compiling, the decoupling
+// has regressed.
+var _ TokenMinter = (*middleware.AuthClient)(nil)
+
+// fakeMinter is a lightweight TokenMinter test double that exercises the mint path
+// without any HTTP round-trip: it returns a canned token or a canned error.
+type fakeMinter struct {
+	token string
+	err   error
+	calls int
+}
+
+func (f *fakeMinter) GetApplicationToken(_ context.Context, _, _ string) (string, error) {
+	f.calls++
+
+	return f.token, f.err
+}
+
+// TestConfigAuth_AcceptsRealAuthClient proves the concrete v3 *middleware.AuthClient
+// still satisfies Config.Auth (now typed as TokenMinter) end-to-end: it mints against
+// a real httptest AUTH server and the publish succeeds against a real identity server.
+func TestConfigAuth_AcceptsRealAuthClient(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	cfg := testConfig(t, auth.URL, identity.URL)
+
+	// The field accepts the concrete *middleware.AuthClient built by testConfig.
+	realClient, ok := cfg.Auth.(*middleware.AuthClient)
+	require.True(t, ok, "testConfig must wire a real *middleware.AuthClient into Config.Auth")
+	require.NotNil(t, realClient)
+
+	p := newFastPublisher(t, cfg)
+
+	require.NoError(t, p.Publish(context.Background()))
+	assert.Equal(t, 1, identity.count())
+	assert.Equal(t, "Bearer "+testToken, identity.gotAuth)
+}
+
+// TestPublish_MintFailure_Transient_WithFakeMinter exercises the mint-failure path
+// through the TokenMinter seam (no HTTP), asserting it is classified transient and
+// never reaches the identity server.
+func TestPublish_MintFailure_Transient_WithFakeMinter(t *testing.T) {
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	fm := &fakeMinter{err: errors.New("auth boom")}
+	cfg := Config{
+		Slug:         "plugin-fees",
+		Manifest:     []byte(feesJSON),
+		IdentityAddr: identity.URL,
+		Auth:         fm,
+		ClientID:     testClientID,
+		ClientSecret: testClientSecret,
+	}
+	p := newFastPublisher(t, cfg)
+
+	err := p.Publish(context.Background())
+	require.Error(t, err)
+
+	var pe *PublishError
+	require.ErrorAs(t, err, &pe)
+	assert.False(t, pe.Deterministic, "mint failure must be transient")
+	assert.Equal(t, "mint m2m token", pe.Op)
+	assert.Equal(t, 1, fm.calls, "the minter must have been called exactly once")
+	assert.Equal(t, 0, identity.count(), "a mint failure must never reach the identity server")
+}
+
+// TestPublish_EmptyToken_Deterministic_WithFakeMinter exercises the empty-token path
+// (auth disabled/misconfigured) through the seam: deterministic, no PUT.
+func TestPublish_EmptyToken_Deterministic_WithFakeMinter(t *testing.T) {
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	fm := &fakeMinter{token: ""}
+	cfg := Config{
+		Slug:         "plugin-fees",
+		Manifest:     []byte(feesJSON),
+		IdentityAddr: identity.URL,
+		Auth:         fm,
+		ClientID:     testClientID,
+		ClientSecret: testClientSecret,
+	}
+	p := newFastPublisher(t, cfg)
+
+	err := p.Publish(context.Background())
+	require.Error(t, err)
+
+	var pe *PublishError
+	require.ErrorAs(t, err, &pe)
+	assert.True(t, pe.Deterministic, "empty token must be deterministic (no retry)")
+	assert.Equal(t, 0, identity.count(), "an empty token must never reach the identity server")
+}

--- a/go.mod
+++ b/go.mod
@@ -83,5 +83,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
## What

Adds a new **`auth/declaration`** sub-package to lib-auth: the **D7 startup publisher**. At boot, a component reads its embedded permissions manifest and publishes it to identity via `PUT /v1/declarations/:slug` using an M2M token — the plugin-push trigger for the access-manager permission-inversion architecture.

This is a startup hook (à la `lib-license`), **outside the request path**, standardized across all deployment models (SaaS / Lerian Cloud / BYOC — the component always boots).

## Public API

- `New(Config) (*Publisher, error)` — validates config; enforces `Slug == manifest.Service`.
- `(*Publisher).Publish(ctx)` — one-shot push.
- `(*Publisher).Start(ctx) (stop func(), error)` — background lifecycle.
- `Config.Auth` is a **`TokenMinter` interface** (`GetApplicationToken(ctx, clientID, clientSecret) (string, error)`) — decouples the publisher from the lib-auth major, so **any** lib-auth version (v2/v3) satisfies it and production code no longer imports the `middleware` package.

## Design

- **Correctness lives on the server.** `CanonicalHash` mirrors the identity server model (`plugin-access-manager/.../pkg/model/declaration.go`, **excludes `version`**). The PUT is idempotent-by-hash, so N pods pushing = server no-ops all but the first; no leader-election / distributed lock needed.
- **Cache is a pluggable `Cache{Get,Set}` interface** — `nil` in the pilot, so `credis`/`ristretto` stay out of `go.mod` until a consumer opts in.
- YAML/JSON manifest parsing + `Validate()` (Casdoor-safe names), backoff (`cenkalti/backoff/v5`), deterministic vs transient status handling, fail-open / fail-fast.
- **D10** manifest signing documented as a stub for BYOC/sovereign.

## Dependency delta

Only `gopkg.in/yaml.v3` promoted from indirect → direct. **Zero new modules**; `go.sum` unchanged.

## Testing

`go build ./...` clean, `go vet` clean, `go test -race ./auth/declaration/...` green at **88.8%** coverage. Proven end-to-end locally: real v3 `AuthClient` → `Publish()` → `PUT /v1/declarations/plugin-fees` = 200; M2M enforce grants declared actions and fail-closes on undeclared ones.

## Follow-ups (not in this PR)

L1/L2 cache impl, periodic re-push (`Interval>0`), M2M provisioning automation, D10 signature.