### PR TITLE
ci: migrate workflow jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   GoLangCI-Lint:
     name: Run GoLangCI-Lint to SDK
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -64,7 +64,7 @@ jobs:
 
   GoSec:
     name: Run GoSec to SDK
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   publish_release:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment:
       name: create_release
     name: Create Release to Lib


### PR DESCRIPTION
The org is standardizing CI on Blacksmith runners, a drop-in replacement for GitHub-hosted runners that is roughly 2x faster at about half the per-minute price. This swaps the GitHub-hosted ubuntu labels for the same `blacksmith-4vcpu-ubuntu-2404` label the rest of the org uses; nothing else in the workflows changes.

```yaml
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
```