### PR TITLE
chore(ci): migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   GoLangCI-Lint:
     name: Run GoLangCI-Lint to SDK
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -64,7 +64,7 @@ jobs:
 
   GoSec:
     name: Run GoSec to SDK
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   publish_release:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment:
       name: create_release
     name: Create Release to Lib


### PR DESCRIPTION
Migrates this repository's GitHub Actions jobs from GitHub-hosted runners to Blacksmith runners, as part of the org-wide migration. Every hardcoded `ubuntu-*` label (both `runs-on:` and `runner_type:` inputs passed to shared workflows) now points to Blacksmith:

```yaml
runs-on: blacksmith-4vcpu-ubuntu-2404
```

Jobs pinned to `ubuntu-22.04` map to `blacksmith-4vcpu-ubuntu-2204` to keep the same OS version. Self-hosted labels (`eveo-*`, `self-hosted`) are untouched, and no other workflow logic changed.
