### PR TITLE
feat(declaration): reject HTTP-verb actions in manifest validation

### DIFF
--- a/auth/declaration/manifest.go
+++ b/auth/declaration/manifest.go
@@ -20,6 +20,20 @@ const (
 	effectDeny  = "deny"
 )
 
+// httpVerbActions is the set of HTTP methods that map 1:1 onto CRUD semantic actions
+// (post->create, get->read, put/patch->update) and are therefore NEVER valid as a
+// declared action: the SEMANTIC action naming standard requires the domain intent, not
+// the transport verb. "delete" is deliberately EXCLUDED — it is the one HTTP method
+// that is also a valid semantic action (delete == delete). The set is kept conservative
+// (head/options/trace/connect are NOT listed) to match the documented HTTP->semantic
+// mapping and avoid false positives on legitimate domain verbs.
+var httpVerbActions = map[string]struct{}{
+	"post":  {},
+	"get":   {},
+	"put":   {},
+	"patch": {},
+}
+
 // DeclarationManifest is the wire model for a plugin's access-manager declaration
 // (the body of PUT /v1/declarations/{slug}). It is a faithful client-side mirror of
 // the server model
@@ -45,8 +59,10 @@ type DeclarationManifest struct {
 }
 
 // DeclarationPermission is a single declared permission. The action is SEMANTIC
-// (create/read/update/delete), never an HTTP verb. The resource is written bare;
-// the central reconciler composes the `{service}/` prefix.
+// (create/read/update/delete), never an HTTP verb — Validate ENFORCES this, rejecting
+// post/get/put/patch (case-insensitive); "delete" is allowed as it is the one HTTP
+// method that is also a valid semantic action. The resource is written bare; the
+// central reconciler composes the `{service}/` prefix.
 type DeclarationPermission struct {
 	Resource string   `json:"resource,omitempty" yaml:"resource,omitempty"`
 	Action   string   `json:"action,omitempty" yaml:"action,omitempty"`
@@ -261,6 +277,8 @@ func (m *DeclarationManifest) validatePermissions(declaredRoles map[string]struc
 
 		if strings.TrimSpace(p.Action) == "" {
 			violations = append(violations, fmt.Sprintf("permissions[%d]: action must not be empty", i))
+		} else if _, isHTTPVerb := httpVerbActions[strings.ToLower(strings.TrimSpace(p.Action))]; isHTTPVerb {
+			violations = append(violations, fmt.Sprintf("permissions[%d]: action %q is an HTTP verb; declare a SEMANTIC action (create/read/update/delete or a domain verb) — only \"delete\" is an HTTP method that is also a valid semantic action", i, p.Action))
 		}
 
 		if p.Effect != effectAllow && p.Effect != effectDeny {

--- a/auth/declaration/manifest_test.go
+++ b/auth/declaration/manifest_test.go
@@ -189,7 +189,13 @@ func TestValidate_Valid(t *testing.T) {
 // action naming standard. The rejection is case-insensitive (compared on the trimmed,
 // lowercased action) and the error names the offending (original-case) action.
 func TestValidate_RejectsHTTPVerbActions(t *testing.T) {
-	verbs := []string{"post", "get", "put", "patch", "POST", "GET", "Put", "PaTcH"}
+	verbs := []string{
+		"post", "get", "put", "patch", "POST", "GET", "Put", "PaTcH",
+		// Whitespace-padded: the validator trims before comparing, so surrounding
+		// spaces must NOT let an HTTP verb slip through. The error still names the
+		// original (untrimmed) action.
+		" post ", "  PATCH  ",
+	}
 
 	for _, verb := range verbs {
 		t.Run(verb, func(t *testing.T) {
@@ -213,7 +219,13 @@ func TestValidate_RejectsHTTPVerbActions(t *testing.T) {
 // the one HTTP method that is ALSO a valid semantic action — and domain verbs are
 // accepted by the HTTP-verb rule (no error attributable to that rule).
 func TestValidate_AllowsSemanticActions(t *testing.T) {
-	actions := []string{"create", "read", "update", "delete", "DELETE", "rotate"}
+	actions := []string{
+		"create", "read", "update", "delete", "DELETE", "rotate",
+		// HTTP methods that are NOT in the CRUD-mapping reject set: only
+		// post/get/put/patch are rejected, so every other HTTP method (head,
+		// options, trace, connect) is a legitimate declared action.
+		"head", "options", "trace", "connect",
+	}
 
 	for _, action := range actions {
 		t.Run(action, func(t *testing.T) {

--- a/auth/declaration/manifest_test.go
+++ b/auth/declaration/manifest_test.go
@@ -1,6 +1,7 @@
 package declaration
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -181,6 +182,71 @@ func TestValidate_Valid(t *testing.T) {
 	m, err := parseManifest([]byte(feesJSON))
 	require.NoError(t, err)
 	require.NoError(t, m.Validate())
+}
+
+// TestValidate_RejectsHTTPVerbActions asserts an action that is an HTTP verb mapping
+// to CRUD (post/get/put/patch, case-insensitive) is rejected, enforcing the SEMANTIC
+// action naming standard. The rejection is case-insensitive (compared on the trimmed,
+// lowercased action) and the error names the offending (original-case) action.
+func TestValidate_RejectsHTTPVerbActions(t *testing.T) {
+	verbs := []string{"post", "get", "put", "patch", "POST", "GET", "Put", "PaTcH"}
+
+	for _, verb := range verbs {
+		t.Run(verb, func(t *testing.T) {
+			raw := fmt.Sprintf(`{"service":"s","version":1,"roles":[{"name":"x"}],"permissions":[{"resource":"r","action":%q,"effect":"allow","roles":["x"]}]}`, verb)
+
+			m, err := parseManifest([]byte(raw))
+			require.NoError(t, err)
+
+			verr := m.Validate()
+			require.Error(t, verr, "an HTTP-verb action must be rejected")
+
+			var me *ManifestError
+			require.ErrorAs(t, verr, &me, "validation error must be a *ManifestError")
+			assert.Contains(t, me.Reason, "is an HTTP verb", "error must explain the HTTP-verb rejection")
+			assert.Contains(t, me.Reason, verb, "error must name the offending action")
+		})
+	}
+}
+
+// TestValidate_AllowsSemanticActions asserts semantic actions — including "delete",
+// the one HTTP method that is ALSO a valid semantic action — and domain verbs are
+// accepted by the HTTP-verb rule (no error attributable to that rule).
+func TestValidate_AllowsSemanticActions(t *testing.T) {
+	actions := []string{"create", "read", "update", "delete", "DELETE", "rotate"}
+
+	for _, action := range actions {
+		t.Run(action, func(t *testing.T) {
+			raw := fmt.Sprintf(`{"service":"s","version":1,"roles":[{"name":"x"}],"permissions":[{"resource":"r","action":%q,"effect":"allow","roles":["x"]}]}`, action)
+
+			m, err := parseManifest([]byte(raw))
+			require.NoError(t, err)
+
+			require.NoError(t, m.Validate(), "a semantic action must be accepted")
+		})
+	}
+}
+
+// TestValidate_AggregatesHTTPVerbActions asserts the HTTP-verb violation is part of the
+// aggregated *ManifestError: multiple offending permissions are all reported together,
+// each attributed to its index, consistent with the sibling aggregated checks.
+func TestValidate_AggregatesHTTPVerbActions(t *testing.T) {
+	raw := `{"service":"s","version":1,"roles":[{"name":"x"}],"permissions":[` +
+		`{"resource":"r0","action":"post","effect":"allow","roles":["x"]},` +
+		`{"resource":"r1","action":"get","effect":"allow","roles":["x"]}]}`
+
+	m, err := parseManifest([]byte(raw))
+	require.NoError(t, err)
+
+	verr := m.Validate()
+	require.Error(t, verr)
+
+	var me *ManifestError
+	require.ErrorAs(t, verr, &me, "validation error must be a *ManifestError")
+	assert.Contains(t, me.Reason, "permissions[0]", "first violation must be reported")
+	assert.Contains(t, me.Reason, "permissions[1]", "second violation must be reported")
+	assert.Contains(t, me.Reason, `"post"`, "first offending action must be named")
+	assert.Contains(t, me.Reason, `"get"`, "second offending action must be named")
 }
 
 func TestValidate_RejectsBadManifests(t *testing.T) {


### PR DESCRIPTION
## What

Enforces the **SEMANTIC action** naming standard for D7 permission-declaration manifests, which until now was only a doc-comment convention. `DeclarationManifest.Validate()` now rejects any permission whose `action` is **`post`/`get`/`put`/`patch`** (case-insensitive) — the REST verbs that map onto CRUD (`post`→create, `get`→read, `put`/`patch`→update) and are never valid semantic actions.

**`delete` stays valid** — it is an HTTP method AND a valid semantic action. `head`/`options`/`trace`/`connect` are intentionally not rejected (they'd risk false positives on domain verbs; the four CRUD-mapping verbs are the real footgun).

## Why

The action a plugin declares must match what its `AuthClient.Authorize(service, resource, action)` guards pass at runtime. An HTTP-verb action silently declares a permission the guards can never match → broken authz. Making it a **boot-time** failure (`New` runs `Validate` eagerly) forces the plugin onto the semantic standard instead of shipping a dead permission. `midaz-fees` (HTTP-verb actions) is the concrete case this catches.

## How

- New package-level set `httpVerbActions = {post, get, put, patch}` next to the `effectAllow`/`effectDeny` consts.
- One `else if` chained onto the existing empty-`action` check in `validatePermissions`, appending into the same aggregated `ManifestError` (all violations still reported together).
- `Action` field doc comment updated: the "never an HTTP verb" line is now ENFORCED, not advisory.

## Testing (TDD, hermetic)

- `TestValidate_RejectsHTTPVerbActions` — `post/get/put/patch` + case variants (`POST/GET/Put/PaTcH`).
- `TestValidate_AllowsSemanticActions` — `create/read/update/delete/DELETE/rotate` all pass.
- `TestValidate_AggregatesHTTPVerbActions` — two verb permissions both reported in one aggregated error.

`gofmt`/`go build ./...`/`go vet`/`go test ./auth/declaration/...` all clean.

## Follow-up (separate repo, not in this PR)

The server-side mirror `plugin-access-manager .../identity/pkg/model/declaration.go` should get the identical rule for lock-step defense-in-depth (the client validator is advisory; the identity server is the true gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)