### PR TITLE
feat(middleware): dynamic JWKS key source for M2M token verification

### DIFF
--- a/DESIGN-jwks-keysource.md
+++ b/DESIGN-jwks-keysource.md
@@ -51,9 +51,12 @@ auth's cached keys as standard JWKS-JSON so downstream can parse with the same c
 // KeySource yields the current set of acceptable RSA verification keys.
 // Keys() NEVER blocks on the network (serve-from-cache, serve-stale on failure).
 // Refresh() forces a single-flight re-fetch; used on signature-verification failure.
+// Close() stops any background refresher and releases resources; idempotent and safe
+// to call on a source with no background goroutine (e.g. StaticKeySource).
 type KeySource interface {
     Keys(ctx context.Context) []*rsa.PublicKey
     Refresh(ctx context.Context) error
+    Close() error
 }
 ```
 
@@ -62,6 +65,19 @@ type KeySource interface {
   - `URL string` (JWKS endpoint), `RefreshInterval time.Duration` (short TTL, e.g. 5m),
   - `BootstrapPEM []byte` (seed), `HTTPClient *http.Client` (TLS/cert-pin injected by caller),
   - `Logger`. Seeds cache from BootstrapPEM; starts background TTL refresh; lazy first live fetch.
+  - `ForcedRefreshCooldown time.Duration` — minimum interval between two forced
+    (signature-failure-triggered) upstream fetches; the refresh-amplification guard.
+    Defaults to 15s when zero. Only the forced `Refresh` path is throttled; the
+    background TTL loop is not.
+  - `Ctx context.Context` — bounds the background refresh goroutine's lifecycle;
+    cancelling it stops the background refresher (graceful shutdown / leak-free tests).
+    Defaults to `context.Background()`. (`Close()` also stops it regardless.)
+  - `AllowInsecureURL bool` — permit a non-HTTPS, non-loopback JWKS URL. The JWKS is
+    the trust root for token verification, so plaintext is rejected by default
+    (fail-closed). Loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) are always
+    allowed without this flag. Set true ONLY for a deliberate case (e.g. a ClusterIP
+    where a service mesh terminates mTLS out-of-band); doing so emits a loud WARN at
+    construction and on each refresh.
 - `NewM2MAuthenticatorWithKeySource(source KeySource, expectedIssuer string, enabled bool, logger *log.Logger) (*M2MAuthenticator, error)`
   - `M2MAuthenticator` gains a `source KeySource` field (nil ⇒ legacy static `publicKey` path).
   - `verify` becomes: `keys := source.Keys(ctx)` → `verifyToken(keys,...)`; if err is a

--- a/DESIGN-jwks-keysource.md
+++ b/DESIGN-jwks-keysource.md
@@ -1,0 +1,92 @@
+# lib-auth: dynamic JWKS key-source for M2M verification (PAM card #3755)
+
+**Status:** design FROZEN (unanimous 3-judge panel). Implement to spec; do NOT re-derive architecture.
+
+## Problem
+M2M JWT verification today pins a single build-time RSA public key (embedded PEM in
+plugin-access-manager `pkg/casdoor/certificates/token_jwt_key.pem`). Casdoor regenerates
+its keypair on reseed and **republishes under the SAME `kid` = `cert-built-in`** (kid is the
+cert NAME, not a content hash). So:
+- a captured PEM stops matching a fresh Casdoor → `401 token signature is invalid`;
+- key rotation requires rebuild+redeploy.
+
+## Goal
+Verify against JWKS fetched dynamically from a configured issuer URL, while keeping
+verification **fail-CLOSED** and availability **fail-OPEN** (serve-stale).
+
+## Non-negotiable constraints
+1. **verifyToken stays authoritative on algorithm.** Keep the existing
+   `verification.go:verifyToken` pinning `RS256` + `exp` + `iss`. The JWKS lib
+   (`github.com/MicahParks/jwkset`) is used ONLY to fetch+parse JWKS-JSON into
+   `[]*rsa.PublicKey`. Do NOT delegate alg enforcement to keyfunc/jwkset.
+2. **Additive only.** Existing `NewM2MAuthenticator(certificatePEM, expectedIssuer, enabled, logger)`
+   keeps its signature and behavior (static single PEM). Add a NEW constructor for the
+   key-source path. Static PEM stays the default. Minor version bump (~v3.5.0-beta).
+3. **THE gotcha — refresh on signature failure.** Because kid is stable, refresh-on-unknown-kid
+   never fires. On a signature-verification failure, force ONE JWKS refresh (single-flight) and
+   retry verifyToken once. Plus a short background TTL refresh.
+4. **Fail-open availability / fail-closed verification.** Serve keys ALWAYS from an in-memory
+   cache. Never block a verify on the network. If the JWKS endpoint is down, serve the last
+   good (stale) keys. A bad signature/alg/exp/iss is still a hard 401.
+5. **Bootstrap seed + lazy fetch.** Cache is seeded at construction from a local bootstrap PEM
+   (embedded/mounted) so the process boots and verifies even if the JWKS endpoint is unreachable
+   at startup. First live fetch is lazy/async.
+6. **Single-flight.** Concurrent refresh requests collapse to one in-flight fetch
+   (`golang.org/x/sync/singleflight` or an equivalent guard already vendored — check go.sum;
+   otherwise a mutex+inflight-flag).
+7. **Consume over ClusterIP, TLS + cert-pin on the fetch.** The KeySource's HTTP client must
+   support TLS with an optional pinned CA/cert (config-provided). Never hairpin the ingress.
+
+## Topology (why a generic URL)
+Only PAM's `auth` and `identity` components reach Casdoor. Downstream plugins cannot; they
+already reach `plugin-access-manager-auth:4000`. So:
+- `auth` + `identity` KeySource JWKS URL → Casdoor `/.well-known/jwks`.
+- downstream plugins KeySource JWKS URL → auth's `/internal/idp-jwks-cache` (read-through cache).
+Same KeySource code, different URL. The auth endpoint (built in PAM, separate task) re-serves
+auth's cached keys as standard JWKS-JSON so downstream can parse with the same code path.
+
+## API to add (lib-auth)
+
+```go
+// KeySource yields the current set of acceptable RSA verification keys.
+// Keys() NEVER blocks on the network (serve-from-cache, serve-stale on failure).
+// Refresh() forces a single-flight re-fetch; used on signature-verification failure.
+type KeySource interface {
+    Keys(ctx context.Context) []*rsa.PublicKey
+    Refresh(ctx context.Context) error
+}
+```
+
+- `StaticKeySource(pubKeys ...*rsa.PublicKey) KeySource` — wraps today's static behavior; Refresh is a no-op. (Lets the existing constructor internally become a StaticKeySource without behavior change — optional refactor, keep back-compat.)
+- `NewJWKSKeySource(cfg JWKSConfig) (KeySource, error)` where JWKSConfig carries:
+  - `URL string` (JWKS endpoint), `RefreshInterval time.Duration` (short TTL, e.g. 5m),
+  - `BootstrapPEM []byte` (seed), `HTTPClient *http.Client` (TLS/cert-pin injected by caller),
+  - `Logger`. Seeds cache from BootstrapPEM; starts background TTL refresh; lazy first live fetch.
+- `NewM2MAuthenticatorWithKeySource(source KeySource, expectedIssuer string, enabled bool, logger *log.Logger) (*M2MAuthenticator, error)`
+  - `M2MAuthenticator` gains a `source KeySource` field (nil ⇒ legacy static `publicKey` path).
+  - `verify` becomes: `keys := source.Keys(ctx)` → `verifyToken(keys,...)`; if err is a
+    **signature/keys** failure AND not yet retried → `source.Refresh(ctx)` → re-`Keys()` → retry once.
+    exp/iss/type/sub failures are NOT retried (they aren't key-staleness).
+
+## Reuse in the repo
+- Existing `verifyToken` (verification.go:36), `parseRSAPublicKeys` (verification.go:180) for PEM→keys.
+- Check `resilience.go` and `decisioncache.go` in `auth/middleware/` for existing single-flight /
+  TTL-cache / retry helpers before adding new ones — prefer reusing them.
+- jwkset v0.11.0 + keyfunc/v3 v3.8.0 are already in the local mod cache (offline build OK).
+  Use jwkset to unmarshal the JWKS-JSON response and enumerate keys; type-assert `*rsa.PublicKey`.
+
+## Observability (task 1.1.8, can be a follow-up but leave hooks)
+Emit: `jwks_cache_age_seconds`, `jwks_unknown_kid_total`, `jwks_verify_fail_total`,
+`jwks_refresh_total{result}`. Follow lib-observability conventions already used in this package.
+
+## Tests (TDD — write first)
+- static path unchanged (existing tests green).
+- JWKS happy path: token signed by fetched key verifies.
+- **gotcha**: cache holds OLD key, token signed by NEW key (same kid) → first verify fails →
+  forced refresh pulls NEW key → retry verifies. Assert exactly ONE refresh, one retry.
+- serve-stale: JWKS endpoint 500s → Keys() still returns last-good; a token from a still-valid
+  cached key verifies (fail-open availability).
+- fail-closed: bad alg (HS256/none), expired exp, wrong iss, empty sub, type!=application → 401/403,
+  and NO refresh loop for non-key failures.
+- single-flight: N concurrent Refresh() → 1 HTTP fetch.
+- bootstrap seed: construct with endpoint unreachable → Keys() returns the seeded key immediately.

--- a/auth/middleware/keysource.go
+++ b/auth/middleware/keysource.go
@@ -44,6 +44,12 @@ const (
 	// rejected as a defensive (DoS) guard.
 	maxJWKSKeys = 32
 
+	// maxJWKSRedirects caps redirect hops on a JWKS fetch. A custom CheckRedirect
+	// REPLACES net/http's default 10-hop cap, so we must re-impose one: otherwise a
+	// compromised endpoint could return policy-compliant https redirects in a loop
+	// and tie up the fetch for the whole timeout (CWE-400). Matches the stdlib default.
+	maxJWKSRedirects = 10
+
 	// jwksRefreshFlightKey is the fixed single-flight key: all refreshes target the
 	// same JWKS URL, so concurrent forced refreshes collapse onto one in-flight fetch.
 	jwksRefreshFlightKey = "refresh"
@@ -547,7 +553,14 @@ func (s *jwksKeySource) fetch(ctx context.Context) ([]*rsa.PublicKey, map[string
 	// fail-closed https policy). Shallow-copy the client so CheckRedirect is overridden
 	// WITHOUT mutating the caller-injected client; the copy shares the Transport (intended).
 	client := *s.httpClient
-	client.CheckRedirect = func(hopReq *http.Request, _ []*http.Request) error {
+	client.CheckRedirect = func(hopReq *http.Request, via []*http.Request) error {
+		// A custom CheckRedirect replaces net/http's default hop cap, so re-impose one:
+		// a compromised endpoint could otherwise loop policy-compliant redirects for the
+		// whole fetch timeout (CWE-400).
+		if len(via) >= maxJWKSRedirects {
+			return fmt.Errorf("jwks fetch stopped after %d redirects", maxJWKSRedirects)
+		}
+
 		// Re-run the construction-time policy on the redirect target. A non-nil error
 		// aborts the redirect (the hop is NOT followed); the warn bool is irrelevant here.
 		if _, verr := validateJWKSURL(hopReq.URL.String(), s.allowInsecure); verr != nil {

--- a/auth/middleware/keysource.go
+++ b/auth/middleware/keysource.go
@@ -1,0 +1,488 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/LerianStudio/lib-observability/v2/log"
+	obsruntime "github.com/LerianStudio/lib-observability/v2/runtime"
+	"github.com/MicahParks/jwkset"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// defaultJWKSRefreshInterval is the short background TTL after which the JWKS
+	// cache is proactively re-fetched. Kept small so a key rotation propagates
+	// quickly; the forced refresh-on-signature-failure is the fast path, this is
+	// the steady-state backstop.
+	defaultJWKSRefreshInterval = 5 * time.Minute
+
+	// defaultJWKSFetchTimeout bounds a single JWKS HTTP fetch when the caller does
+	// not inject an HTTP client with its own timeout.
+	defaultJWKSFetchTimeout = 10 * time.Second
+
+	// maxJWKSResponseBytes caps the JWKS response read so a hostile or misbehaving
+	// endpoint cannot exhaust memory. A JWKS with a handful of RSA keys is a few KB.
+	maxJWKSResponseBytes = 1 << 20 // 1 MiB
+
+	// jwksRefreshFlightKey is the fixed single-flight key: all refreshes target the
+	// same JWKS URL, so concurrent forced refreshes collapse onto one in-flight fetch.
+	jwksRefreshFlightKey = "refresh"
+
+	// defaultForcedRefreshCooldown is the minimum interval between two forced
+	// (signature-failure-triggered) upstream JWKS fetches. It caps refresh
+	// amplification: a stream of DISTINCT bad-signature tokens cannot drive one
+	// upstream fetch per request (single-flight only collapses CONCURRENT calls, not
+	// sequential ones). Within the window a forced Refresh serves stale and returns
+	// nil without hitting upstream; verification still fails closed on the retry. The
+	// background TTL loop is NOT throttled by this — only the forced path is.
+	defaultForcedRefreshCooldown = 15 * time.Second
+)
+
+// KeySource yields the current set of acceptable RSA verification keys.
+//
+// Keys NEVER blocks on the network: it serves from an in-memory cache and, on a
+// backend failure, serves the last-good (stale) keys — fail-OPEN on availability.
+// Refresh is the FORCED re-fetch the M2M gate calls on a signature verification
+// failure to pull a rotated key (the stable-kid Casdoor case, where
+// refresh-on-unknown-kid never fires); it is single-flight AND rate-limited by a
+// forced-refresh cooldown so a stream of bad tokens cannot amplify into one
+// upstream fetch per request — within the cooldown it serves stale and returns nil.
+// Close stops any background refresher and releases resources; it is idempotent and
+// safe to call on a source with no background goroutine. Verification itself stays
+// fail-CLOSED: a bad signature/alg/exp/iss is always rejected by verifyToken.
+type KeySource interface {
+	Keys(ctx context.Context) []*rsa.PublicKey
+	Refresh(ctx context.Context) error
+	Close() error
+}
+
+// staticKeySource wraps a fixed key set (today's build-time single-PEM behavior).
+// Refresh is a no-op: there is no backend to re-fetch from.
+type staticKeySource struct {
+	keys []*rsa.PublicKey
+}
+
+// StaticKeySource returns a KeySource over a fixed set of RSA public keys. It
+// preserves the legacy static-PEM behavior (optionally with rotation overlap) and
+// its Refresh is a no-op.
+func StaticKeySource(pubKeys ...*rsa.PublicKey) KeySource {
+	return &staticKeySource{keys: pubKeys}
+}
+
+func (s *staticKeySource) Keys(_ context.Context) []*rsa.PublicKey { return s.keys }
+
+func (s *staticKeySource) Refresh(_ context.Context) error { return nil }
+
+func (s *staticKeySource) Close() error { return nil }
+
+// JWKSConfig configures a dynamic JWKS-backed KeySource.
+type JWKSConfig struct {
+	// URL is the JWKS-JSON endpoint (e.g. Casdoor's /.well-known/jwks for PAM's
+	// auth/identity, or auth's read-through /internal/idp-jwks-cache for downstream
+	// plugins). Required.
+	URL string
+
+	// RefreshInterval is the short background TTL for proactive re-fetch. Defaults
+	// to defaultJWKSRefreshInterval when zero.
+	RefreshInterval time.Duration
+
+	// ForcedRefreshCooldown is the minimum interval between two forced
+	// (signature-failure-triggered) upstream fetches — the refresh-amplification
+	// guard. Defaults to defaultForcedRefreshCooldown (15s) when zero. Only the
+	// forced Refresh path is throttled; the background TTL loop is not.
+	ForcedRefreshCooldown time.Duration
+
+	// BootstrapPEM seeds the cache at construction (embedded/mounted PEM) so the
+	// process boots and verifies even if the JWKS endpoint is unreachable at
+	// startup. One or more concatenated PEM blocks (rotation overlap supported).
+	BootstrapPEM []byte
+
+	// HTTPClient is the caller-injected client used for the fetch; inject TLS /
+	// pinned-CA transport here (consume over ClusterIP, never hairpin the ingress).
+	// Defaults to a client with defaultJWKSFetchTimeout when nil.
+	HTTPClient *http.Client
+
+	// Logger records refresh outcomes. Defaults to a no-op logger when nil.
+	Logger log.Logger
+
+	// Ctx bounds the background refresh goroutine's lifecycle: cancelling it stops
+	// the background refresher (used for graceful shutdown and to avoid leaking the
+	// goroutine in tests). Defaults to context.Background(). NOTE: additive to the
+	// frozen DESIGN field list — see the task report.
+	Ctx context.Context
+}
+
+// jwksKeySource is an HTTP JWKS-backed KeySource with an in-memory cache, a short
+// background TTL refresh, and single-flight forced refresh.
+type jwksKeySource struct {
+	url             string
+	httpClient      *http.Client
+	refreshInterval time.Duration
+	forcedCooldown  time.Duration
+	logger          log.Logger
+
+	// now is the clock (injectable in tests); defaults to time.Now.
+	now func() time.Time
+
+	// cancel stops the background refresher started by NewJWKSKeySource. nil for a
+	// source built without a background goroutine (the internal test constructor).
+	cancel context.CancelFunc
+
+	group singleflight.Group
+
+	// lastForcedNano is the UnixNano of the last forced refresh that was allowed to
+	// hit upstream; 0 means "never". Read/written atomically to gate the forced path.
+	lastForcedNano atomic.Int64
+
+	mu        sync.RWMutex
+	keys      []*rsa.PublicKey
+	kids      map[string]struct{} // kids present in the current cached JWKS; feeds jwks_unknown_kid_total only. nil for bootstrap/PEM keys (which carry no kid).
+	fetchedAt time.Time           // last successful LIVE fetch; zero => only the bootstrap seed
+
+	// Observability hooks (card 1.1.8): the refreshOK/refreshFail atomics are RETAINED
+	// alongside the jwks_refresh_total{result} counter so the outcome counts stay
+	// directly assertable in unit tests without an OTEL reader. The four metrics
+	// (jwks_refresh_total{result}, jwks_cache_age_seconds, jwks_verify_fail_total,
+	// jwks_unknown_kid_total) are emitted via the lib-observability/v2 metrics factory
+	// resolved from ctx — see metrics.go.
+	refreshOK   atomic.Int64
+	refreshFail atomic.Int64
+}
+
+// kidPresenceChecker is optionally implemented by a KeySource that tracks the kids
+// of its cached JWKS. It exists ONLY to feed jwks_unknown_kid_total; verification
+// never consults it (verifyToken still tries all keys). The static/PEM sources do
+// not implement it — their keys carry no kid — so the metric is JWKS-only.
+type kidPresenceChecker interface {
+	hasKID(kid string) bool
+}
+
+// NewJWKSKeySource builds a dynamic JWKS KeySource: it seeds the cache from the
+// bootstrap PEM (if any), then starts a background goroutine that performs a lazy
+// first live fetch and thereafter refreshes on the short TTL. Construction never
+// blocks on the network, so a slow/unreachable endpoint at startup is fine.
+func NewJWKSKeySource(cfg JWKSConfig) (KeySource, error) {
+	src, err := newJWKSKeySource(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	base := cfg.Ctx
+	if base == nil {
+		base = context.Background()
+	}
+
+	// Derive a cancelable context so Close() can stop the background refresher even
+	// when the caller passed no cfg.Ctx (bound to context.Background()).
+	ctx, cancel := context.WithCancel(base)
+	src.cancel = cancel
+
+	// Lazy first live fetch + short-TTL background refresh. Keys() never waits on
+	// this. SafeGoWithContext gives panic recovery on the goroutine boundary.
+	obsruntime.SafeGoWithContext(ctx, src.logger, "lib-auth.jwks-refresher", obsruntime.KeepRunning, src.refreshLoop)
+
+	return src, nil
+}
+
+// newJWKSKeySource builds the source and seeds the bootstrap keys WITHOUT starting
+// the background goroutine. Split out so tests can drive Refresh deterministically.
+func newJWKSKeySource(cfg JWKSConfig) (*jwksKeySource, error) {
+	if strings.TrimSpace(cfg.URL) == "" {
+		return nil, errors.New("jwks key source requires a non-empty URL")
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.NewNop()
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultJWKSFetchTimeout}
+	}
+
+	interval := cfg.RefreshInterval
+	if interval <= 0 {
+		interval = defaultJWKSRefreshInterval
+	}
+
+	cooldown := cfg.ForcedRefreshCooldown
+	if cooldown <= 0 {
+		cooldown = defaultForcedRefreshCooldown
+	}
+
+	// TLS is expected on the key fetch (consume over ClusterIP with a pinned CA).
+	// Warn — but do NOT fail — on a non-https URL: local/dev reaches Casdoor over http.
+	if u, perr := url.Parse(cfg.URL); perr == nil && u.Scheme != "" && u.Scheme != "https" {
+		logger.Log(context.Background(), log.LevelWarn,
+			fmt.Sprintf("JWKS URL scheme %q is not https; use https in production for the key fetch", u.Scheme))
+	}
+
+	src := &jwksKeySource{
+		url:             cfg.URL,
+		httpClient:      httpClient,
+		refreshInterval: interval,
+		forcedCooldown:  cooldown,
+		logger:          logger,
+		now:             time.Now,
+	}
+
+	if len(cfg.BootstrapPEM) > 0 {
+		keys, err := parseRSAPublicKeys(cfg.BootstrapPEM)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse jwks bootstrap PEM: %w", err)
+		}
+
+		src.setKeys(keys, nil, time.Time{}) // seed only; not a live fetch (PEM keys carry no kid)
+	}
+
+	return src, nil
+}
+
+// Keys returns the currently cached verification keys without ever touching the
+// network (serve-from-cache, serve-stale). May be empty before the first
+// successful fetch when no bootstrap PEM was provided; verifyToken then fails closed.
+func (s *jwksKeySource) Keys(ctx context.Context) []*rsa.PublicKey {
+	s.mu.RLock()
+	keys := s.keys
+	fetchedAt := s.fetchedAt
+	s.mu.RUnlock()
+
+	s.emitCacheAge(ctx, fetchedAt)
+
+	return keys
+}
+
+// hasKID reports whether kid is one of the kids in the current cached JWKS. Used
+// only to emit jwks_unknown_kid_total (see kidPresenceChecker); it never gates
+// verification. A bootstrap/PEM-seeded source (kids == nil) reports false for every
+// kid — accurate: no JWKS-published kid has been observed yet.
+func (s *jwksKeySource) hasKID(kid string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.kids[kid]
+
+	return ok
+}
+
+// emitCacheAge records jwks_cache_age_seconds for the currently-served keys. It is a
+// no-op until the first successful LIVE fetch (zero fetchedAt => only a bootstrap
+// seed), so a seed-only source never reports a spurious multi-decade age. The clock
+// is s.now (injectable in tests). Emission is cheap and never blocks Keys.
+func (s *jwksKeySource) emitCacheAge(ctx context.Context, fetchedAt time.Time) {
+	if fetchedAt.IsZero() {
+		return
+	}
+
+	age := int64(s.now().Sub(fetchedAt).Seconds())
+	if age < 0 {
+		age = 0
+	}
+
+	setJWKSGauge(ctx, metricJWKSCacheAgeSeconds, age)
+}
+
+// Refresh is the FORCED, cooldown-gated re-fetch invoked by the M2M gate on a
+// signature/keys failure. It caps refresh amplification: at most one upstream fetch
+// per forcedCooldown window. Within the window it returns nil WITHOUT hitting
+// upstream (serve-stale) — the caller's retry still verifies against the cached keys
+// and fails closed if they don't match. Concurrent forced calls also collapse via
+// single-flight. The stable-kid fast path is preserved: the first forced refresh
+// (lastForcedNano == 0) always fires, so a real rotation refreshes promptly.
+func (s *jwksKeySource) Refresh(ctx context.Context) error {
+	now := s.now().UnixNano()
+
+	if last := s.lastForcedNano.Load(); last != 0 && now-last < s.forcedCooldown.Nanoseconds() {
+		return nil // gated: serve stale, do not hit upstream
+	}
+
+	// Claim the window before fetching so a slow/failing fetch does not let a burst
+	// of sequential requests each start their own upstream call.
+	s.lastForcedNano.Store(now)
+
+	return s.refreshNow(ctx)
+}
+
+// refreshNow performs the single-flight re-fetch WITHOUT the cooldown gate.
+// Concurrent callers collapse onto one in-flight HTTP request and share its
+// outcome. On failure the cache is left untouched (serve-stale) and the error is
+// returned. Used by the background TTL loop (which must not be throttled) and by
+// the cooldown-gated Refresh.
+func (s *jwksKeySource) refreshNow(ctx context.Context) error {
+	_, err, _ := s.group.Do(jwksRefreshFlightKey, func() (any, error) {
+		keys, kids, ferr := s.fetch(ctx)
+		if ferr != nil {
+			s.refreshFail.Add(1)
+			incrJWKSCounter(ctx, metricJWKSRefreshTotal, map[string]string{"result": "fail"})
+
+			return nil, ferr
+		}
+
+		s.setKeys(keys, kids, s.now())
+		s.refreshOK.Add(1)
+		incrJWKSCounter(ctx, metricJWKSRefreshTotal, map[string]string{"result": "ok"})
+
+		return nil, nil
+	})
+
+	return err
+}
+
+// Close stops the background refresher (if any) and is idempotent. A source built
+// without a background goroutine (the internal test constructor) has no cancel and
+// Close is a no-op.
+func (s *jwksKeySource) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	return nil
+}
+
+// refreshLoop performs the lazy first live fetch, then refreshes on the TTL until
+// the context is cancelled. Failures are logged and swallowed: the cache keeps
+// serving the last-good keys (fail-open availability).
+func (s *jwksKeySource) refreshLoop(ctx context.Context) {
+	// The background loop uses the UN-gated fetch: the periodic TTL refresh must not
+	// be throttled by the forced-refresh cooldown.
+	if err := s.refreshNow(ctx); err != nil {
+		s.logWarn(ctx, "initial JWKS fetch failed; serving bootstrap/stale keys: %v", err)
+	}
+
+	ticker := time.NewTicker(s.refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.refreshNow(ctx); err != nil {
+				s.logWarn(ctx, "background JWKS refresh failed; serving stale keys: %v", err)
+			}
+		}
+	}
+}
+
+// fetch performs one JWKS HTTP GET and parses the response into RSA public keys.
+// It never mutates the cache; the caller decides whether to install the result.
+func (s *jwksKeySource) fetch(ctx context.Context) ([]*rsa.PublicKey, map[string]struct{}, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.url, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build jwks request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch jwks: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("jwks endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxJWKSResponseBytes))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read jwks response: %w", err)
+	}
+
+	keys, kids, err := parseJWKSKeysAndKIDs(body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(keys) == 0 {
+		return nil, nil, errors.New("jwks response contained no RSA public keys")
+	}
+
+	return keys, kids, nil
+}
+
+// setKeys atomically replaces the cached keys and their kid set. A non-zero
+// fetchedAt marks a live fetch (drives cache-age); the bootstrap seed passes the
+// zero time (and a nil kid set, since PEM keys carry no kid).
+func (s *jwksKeySource) setKeys(keys []*rsa.PublicKey, kids map[string]struct{}, fetchedAt time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.keys = keys
+	s.kids = kids
+
+	if !fetchedAt.IsZero() {
+		s.fetchedAt = fetchedAt
+	}
+}
+
+// logWarn logs a refresh warning at WARN level (nil-safe), matching the package's
+// logErrorf/logInfof convention. A failed refresh that serves stale is a warning,
+// not an error: verification still works off the cache.
+func (s *jwksKeySource) logWarn(ctx context.Context, format string, args ...any) {
+	if s.logger == nil {
+		return
+	}
+
+	s.logger.Log(ctx, log.LevelWarn, fmt.Sprintf(format, args...))
+}
+
+// parseJWKSKeysAndKIDs unmarshals a JWKS-JSON document and returns its RS256 public
+// keys plus the set of kids of the kept keys. jwkset is used ONLY as a JWKS-JSON ->
+// keys parser here; algorithm enforcement stays authoritative in verifyToken (RS256
+// pin), never delegated to the JWKS layer. Non-RSA keys are ignored (RS256-only
+// verification). The kids feed jwks_unknown_kid_total ONLY (verification is unchanged:
+// keys are still tried without kid lookup). A kept key that omits its kid contributes
+// nothing to the set.
+func parseJWKSKeysAndKIDs(data []byte) ([]*rsa.PublicKey, map[string]struct{}, error) {
+	var marshal jwkset.JWKSMarshal
+	if err := json.Unmarshal(data, &marshal); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal jwks json: %w", err)
+	}
+
+	jwks, err := marshal.JWKSlice()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decode jwks keys: %w", err)
+	}
+
+	keys := make([]*rsa.PublicKey, 0, len(jwks))
+	kids := make(map[string]struct{}, len(jwks))
+
+	for _, jwk := range jwks {
+		pub, ok := jwk.Key().(*rsa.PublicKey)
+		if !ok {
+			continue // non-RSA key: RS256-only verification
+		}
+
+		meta := jwk.Marshal()
+
+		// Exclude a key only when its use is explicitly non-signature or its alg is
+		// explicitly non-RS256. Keys that OMIT use/alg are kept: Casdoor may not set
+		// them, and dropping those would break verification.
+		if meta.USE != "" && meta.USE != jwkset.UseSig {
+			continue
+		}
+
+		if meta.ALG != "" && meta.ALG != jwkset.AlgRS256 {
+			continue
+		}
+
+		keys = append(keys, pub)
+
+		if meta.KID != "" {
+			kids[meta.KID] = struct{}{}
+		}
+	}
+
+	return keys, kids, nil
+}

--- a/auth/middleware/keysource.go
+++ b/auth/middleware/keysource.go
@@ -148,6 +148,12 @@ type jwksKeySource struct {
 	forcedCooldown  time.Duration
 	logger          log.Logger
 
+	// allowInsecure mirrors JWKSConfig.AllowInsecureURL. It is retained on the source
+	// so the SAME transport policy validated at construction is re-applied to every
+	// redirect hop in fetch — an https JWKS URL must not be bounced to a plaintext
+	// non-loopback target whose response would then be cached as a trust root (CWE-319).
+	allowInsecure bool
+
 	// warnInsecure is set when the URL is plaintext http against a non-loopback host
 	// with AllowInsecureURL opted in. It drives a loud WARN at construction AND on
 	// each refresh so an accidental prod enablement stays visible/alertable.
@@ -271,6 +277,7 @@ func newJWKSKeySource(cfg JWKSConfig) (*jwksKeySource, error) {
 		forcedCooldown:  cooldown,
 		logger:          logger,
 		warnInsecure:    warnInsecure,
+		allowInsecure:   cfg.AllowInsecureURL,
 		now:             time.Now,
 	}
 
@@ -296,6 +303,13 @@ func validateJWKSURL(raw string, allowInsecure bool) (warn bool, err error) {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return false, fmt.Errorf("invalid jwks url %q: %w", raw, err)
+	}
+
+	// A scheme-only URL (e.g. "https:///jwks") parses cleanly and passes the scheme
+	// check, but has no host to dial: every fetch would then fail to build a usable
+	// request. Reject it up front so the misconfiguration fails closed at construction.
+	if u.Hostname() == "" {
+		return false, fmt.Errorf("jwks url %q has no host", raw)
 	}
 
 	switch u.Scheme {
@@ -421,9 +435,15 @@ func (s *jwksKeySource) Refresh(ctx context.Context) error {
 		return nil // gated: serve stale, do not hit upstream
 	}
 
-	// Claim the window before fetching so a slow/failing fetch does not let a burst
-	// of sequential requests each start their own upstream call.
-	s.lastForcedNano.Store(now)
+	// Claim the window ATOMICALLY before fetching. The load/check/store sequence was not
+	// atomic: two callers could both read the same prev, both pass the gate, and — when
+	// their single-flight windows did not overlap — both start an upstream fetch inside
+	// one cooldown window. CompareAndSwap makes the claim the single serialization point:
+	// exactly one caller advances prev->now and fetches; a racing caller's CAS fails and
+	// it serves stale (returns nil) instead of starting a second fetch.
+	if !s.lastForcedNano.CompareAndSwap(prev, now) {
+		return nil
+	}
 
 	err := s.refreshNow(ctx)
 
@@ -521,7 +541,23 @@ func (s *jwksKeySource) fetch(ctx context.Context) ([]*rsa.PublicKey, map[string
 		return nil, nil, fmt.Errorf("failed to build jwks request: %w", err)
 	}
 
-	resp, err := s.httpClient.Do(req)
+	// Enforce the transport policy on EVERY redirect hop, not just the initial URL: a
+	// policy-compliant https URL must not be 302'd to a plaintext non-loopback target
+	// whose response would then be cached as verification keys (CWE-319, defeating the
+	// fail-closed https policy). Shallow-copy the client so CheckRedirect is overridden
+	// WITHOUT mutating the caller-injected client; the copy shares the Transport (intended).
+	client := *s.httpClient
+	client.CheckRedirect = func(hopReq *http.Request, _ []*http.Request) error {
+		// Re-run the construction-time policy on the redirect target. A non-nil error
+		// aborts the redirect (the hop is NOT followed); the warn bool is irrelevant here.
+		if _, verr := validateJWKSURL(hopReq.URL.String(), s.allowInsecure); verr != nil {
+			return fmt.Errorf("jwks redirect to a policy-violating target blocked: %w", verr)
+		}
+
+		return nil
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch jwks: %w", err)
 	}

--- a/auth/middleware/keysource.go
+++ b/auth/middleware/keysource.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,7 +15,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	observability "github.com/LerianStudio/lib-observability/v2"
 	"github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/LerianStudio/lib-observability/v2/metrics"
 	obsruntime "github.com/LerianStudio/lib-observability/v2/runtime"
 	"github.com/MicahParks/jwkset"
 	"golang.org/x/sync/singleflight"
@@ -34,6 +37,12 @@ const (
 	// maxJWKSResponseBytes caps the JWKS response read so a hostile or misbehaving
 	// endpoint cannot exhaust memory. A JWKS with a handful of RSA keys is a few KB.
 	maxJWKSResponseBytes = 1 << 20 // 1 MiB
+
+	// maxJWKSKeys bounds the number of RSA keys accepted from a single JWKS. verifyToken
+	// tries keys until one matches, so an oversized set multiplies per-token RSA work; a
+	// real rotation-overlap JWKS carries at most a few keys. A JWKS exceeding this is
+	// rejected as a defensive (DoS) guard.
+	maxJWKSKeys = 32
 
 	// jwksRefreshFlightKey is the fixed single-flight key: all refreshes target the
 	// same JWKS URL, so concurrent forced refreshes collapse onto one in-flight fetch.
@@ -93,6 +102,13 @@ type JWKSConfig struct {
 	// plugins). Required.
 	URL string
 
+	// AllowInsecureURL permits a non-HTTPS, non-loopback JWKS URL. The JWKS is the
+	// trust root for token verification, so plaintext is rejected by default. Set true
+	// ONLY for a deliberate case — e.g. a ClusterIP where a service mesh terminates
+	// mTLS out-of-band. Loopback hosts (localhost, 127.0.0.0/8, ::1) are always allowed
+	// without this flag.
+	AllowInsecureURL bool
+
 	// RefreshInterval is the short background TTL for proactive re-fetch. Defaults
 	// to defaultJWKSRefreshInterval when zero.
 	RefreshInterval time.Duration
@@ -132,6 +148,11 @@ type jwksKeySource struct {
 	forcedCooldown  time.Duration
 	logger          log.Logger
 
+	// warnInsecure is set when the URL is plaintext http against a non-loopback host
+	// with AllowInsecureURL opted in. It drives a loud WARN at construction AND on
+	// each refresh so an accidental prod enablement stays visible/alertable.
+	warnInsecure bool
+
 	// now is the clock (injectable in tests); defaults to time.Now.
 	now func() time.Time
 
@@ -158,6 +179,13 @@ type jwksKeySource struct {
 	// resolved from ctx — see metrics.go.
 	refreshOK   atomic.Int64
 	refreshFail atomic.Int64
+
+	// cacheAgeGauge is the jwks_cache_age_seconds instrument, built ONCE per source
+	// (guarded by cacheAgeGaugeOnce) so serving keys does not churn a metric builder
+	// or re-WARN on a creation failure on every verify. nil => creation failed or no
+	// factory was resolvable; emission is then skipped (best-effort, never blocks).
+	cacheAgeGaugeOnce sync.Once
+	cacheAgeGauge     *metrics.GaugeBuilder
 }
 
 // kidPresenceChecker is optionally implemented by a KeySource that tracks the kids
@@ -222,11 +250,18 @@ func newJWKSKeySource(cfg JWKSConfig) (*jwksKeySource, error) {
 		cooldown = defaultForcedRefreshCooldown
 	}
 
-	// TLS is expected on the key fetch (consume over ClusterIP with a pinned CA).
-	// Warn — but do NOT fail — on a non-https URL: local/dev reaches Casdoor over http.
-	if u, perr := url.Parse(cfg.URL); perr == nil && u.Scheme != "" && u.Scheme != "https" {
+	// The JWKS is the trust root for token verification, so plaintext is rejected by
+	// default (fail-closed). Loopback http is carved out (local/dev reaches Casdoor over
+	// http); a non-loopback plaintext URL requires an explicit AllowInsecureURL opt-in
+	// and then WARNs loudly.
+	warnInsecure, err := validateJWKSURL(cfg.URL, cfg.AllowInsecureURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if warnInsecure {
 		logger.Log(context.Background(), log.LevelWarn,
-			fmt.Sprintf("JWKS URL scheme %q is not https; use https in production for the key fetch", u.Scheme))
+			fmt.Sprintf("JWKS is fetched over plaintext HTTP against a non-loopback host (URL=%q); the JWKS is the trust root for token verification — enable TLS in production", cfg.URL))
 	}
 
 	src := &jwksKeySource{
@@ -235,6 +270,7 @@ func newJWKSKeySource(cfg JWKSConfig) (*jwksKeySource, error) {
 		refreshInterval: interval,
 		forcedCooldown:  cooldown,
 		logger:          logger,
+		warnInsecure:    warnInsecure,
 		now:             time.Now,
 	}
 
@@ -248,6 +284,52 @@ func newJWKSKeySource(cfg JWKSConfig) (*jwksKeySource, error) {
 	}
 
 	return src, nil
+}
+
+// validateJWKSURL fail-closes on an unusable JWKS URL and reports whether an insecure
+// (plaintext, non-loopback, explicitly-opted-in) URL is in use so the caller can WARN.
+// It rejects a parse error, an empty scheme, or any scheme other than http/https. An
+// https URL is fine; an http URL is fine only for a loopback host, or for a non-loopback
+// host when allowInsecure is true (then warn == true). It performs a PURE literal host
+// check — never a DNS lookup — so it stays non-blocking.
+func validateJWKSURL(raw string, allowInsecure bool) (warn bool, err error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false, fmt.Errorf("invalid jwks url %q: %w", raw, err)
+	}
+
+	switch u.Scheme {
+	case "https":
+		return false, nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return false, nil
+		}
+
+		if !allowInsecure {
+			return false, fmt.Errorf(
+				"jwks url %q uses plaintext http against a non-loopback host; the JWKS is the trust root for token verification — set JWKSConfig.AllowInsecureURL to permit this deliberately",
+				raw)
+		}
+
+		return true, nil
+	default:
+		return false, fmt.Errorf("jwks url %q has unsupported scheme %q (want https, or http for a loopback host)", raw, u.Scheme)
+	}
+}
+
+// isLoopbackHost reports whether host is a loopback target by literal inspection only
+// (no DNS): the name "localhost", or an IP literal in 127.0.0.0/8 or ::1.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+
+	return false
 }
 
 // Keys returns the currently cached verification keys without ever touching the
@@ -291,7 +373,37 @@ func (s *jwksKeySource) emitCacheAge(ctx context.Context, fetchedAt time.Time) {
 		age = 0
 	}
 
-	setJWKSGauge(ctx, metricJWKSCacheAgeSeconds, age)
+	gauge := s.cacheAgeGaugeBuilder(ctx)
+	if gauge == nil {
+		return // instrument unavailable; best-effort, never block verify
+	}
+
+	if err := gauge.Set(ctx, age); err != nil {
+		s.logWarn(ctx, "failed to record metric %q: %v", metricJWKSCacheAgeSeconds.Name, err)
+	}
+}
+
+// cacheAgeGaugeBuilder builds the jwks_cache_age_seconds gauge builder EXACTLY once
+// per source and reuses it thereafter. The lib-observability factory exposes only a
+// synchronous gauge (no observable/async callback), so caching the builder here is the
+// idiomatic way to avoid per-verify instrument churn and, crucially, to WARN at most
+// once on a creation failure rather than on every request. Returns nil when the
+// instrument cannot be created (emission is then skipped, best-effort).
+func (s *jwksKeySource) cacheAgeGaugeBuilder(ctx context.Context) *metrics.GaugeBuilder {
+	s.cacheAgeGaugeOnce.Do(func() {
+		logger, _, _, factory := observability.NewTrackingFromContext(ctx)
+
+		gauge, err := factory.Gauge(metricJWKSCacheAgeSeconds)
+		if err != nil {
+			logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to create metric %q: %v", metricJWKSCacheAgeSeconds.Name, err))
+
+			return
+		}
+
+		s.cacheAgeGauge = gauge
+	})
+
+	return s.cacheAgeGauge
 }
 
 // Refresh is the FORCED, cooldown-gated re-fetch invoked by the M2M gate on a
@@ -304,7 +416,8 @@ func (s *jwksKeySource) emitCacheAge(ctx context.Context, fetchedAt time.Time) {
 func (s *jwksKeySource) Refresh(ctx context.Context) error {
 	now := s.now().UnixNano()
 
-	if last := s.lastForcedNano.Load(); last != 0 && now-last < s.forcedCooldown.Nanoseconds() {
+	prev := s.lastForcedNano.Load()
+	if prev != 0 && now-prev < s.forcedCooldown.Nanoseconds() {
 		return nil // gated: serve stale, do not hit upstream
 	}
 
@@ -312,7 +425,18 @@ func (s *jwksKeySource) Refresh(ctx context.Context) error {
 	// of sequential requests each start their own upstream call.
 	s.lastForcedNano.Store(now)
 
-	return s.refreshNow(ctx)
+	err := s.refreshNow(ctx)
+
+	// A genuinely-cancelled attempt (context.Canceled) never meaningfully reached
+	// upstream, so release the window — otherwise a cancellation could stall a real
+	// key rotation for the whole cooldown. Ordinary fetch failures/timeouts (e.g.
+	// DeadlineExceeded, 5xx) SHOULD hold the window: that is the amplification guard.
+	// CompareAndSwap only restores if no concurrent refresh has since re-claimed it.
+	if err != nil && errors.Is(err, context.Canceled) {
+		s.lastForcedNano.CompareAndSwap(now, prev)
+	}
+
+	return err
 }
 
 // refreshNow performs the single-flight re-fetch WITHOUT the cooldown gate.
@@ -321,8 +445,21 @@ func (s *jwksKeySource) Refresh(ctx context.Context) error {
 // returned. Used by the background TTL loop (which must not be throttled) and by
 // the cooldown-gated Refresh.
 func (s *jwksKeySource) refreshNow(ctx context.Context) error {
+	if s.warnInsecure {
+		s.logWarn(ctx, "JWKS refresh over plaintext HTTP against a non-loopback host (URL=%q); enable TLS in production", s.url)
+	}
+
 	_, err, _ := s.group.Do(jwksRefreshFlightKey, func() (any, error) {
-		keys, kids, ferr := s.fetch(ctx)
+		// Detach the fetch from the caller's (request-scoped) ctx: this fill of the
+		// process-lifetime shared cache must not inherit ONE caller's cancellation —
+		// a client disconnect/timeout must not abort the shared single-flight fetch and
+		// fail every joined verifier. A bounded timeout still prevents a hung fetch.
+		// (The background TTL loop keeps passing the source lifetime ctx; only the fetch
+		// is detached here.)
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), defaultJWKSFetchTimeout)
+		defer cancel()
+
+		keys, kids, ferr := s.fetch(fetchCtx)
 		if ferr != nil {
 			s.refreshFail.Add(1)
 			incrJWKSCounter(ctx, metricJWKSRefreshTotal, map[string]string{"result": "fail"})
@@ -394,9 +531,16 @@ func (s *jwksKeySource) fetch(ctx context.Context) ([]*rsa.PublicKey, map[string
 		return nil, nil, fmt.Errorf("jwks endpoint returned status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxJWKSResponseBytes))
+	// Read ONE byte past the cap: if the body would exceed maxJWKSResponseBytes we can
+	// then report an explicit size error instead of silently truncating into a
+	// misleading "malformed json" parse failure.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxJWKSResponseBytes+1))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read jwks response: %w", err)
+	}
+
+	if len(body) > maxJWKSResponseBytes {
+		return nil, nil, fmt.Errorf("jwks response exceeds %d bytes", maxJWKSResponseBytes)
 	}
 
 	keys, kids, err := parseJWKSKeysAndKIDs(body)
@@ -406,6 +550,12 @@ func (s *jwksKeySource) fetch(ctx context.Context) ([]*rsa.PublicKey, map[string
 
 	if len(keys) == 0 {
 		return nil, nil, errors.New("jwks response contained no RSA public keys")
+	}
+
+	// Bound the key count: verifyToken tries keys until one matches, so an oversized
+	// set multiplies per-token RSA work (a defensive DoS guard).
+	if len(keys) > maxJWKSKeys {
+		return nil, nil, fmt.Errorf("jwks response has %d RSA keys, exceeding the %d-key limit", len(keys), maxJWKSKeys)
 	}
 
 	return keys, kids, nil

--- a/auth/middleware/keysource_test.go
+++ b/auth/middleware/keysource_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -9,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -1084,6 +1086,30 @@ func TestNewJWKSKeySource_InvalidScheme_Rejected(t *testing.T) {
 	}
 }
 
+// A scheme-only URL with an EMPTY host parses fine and passes the scheme check, but
+// every refresh then fails to build a usable request. Reject it at construction so the
+// misconfiguration surfaces immediately, not as a silent perpetual refresh failure.
+func TestNewJWKSKeySource_NoHost_Rejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"https_no_host", "https:///jwks"},
+		{"http_no_host", "http:///jwks"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newJWKSKeySource(JWKSConfig{URL: tt.url})
+			require.Error(t, err, "a URL with no host must be rejected at construction")
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // FIX 4: bound the response size (detect truncation) and the key count
 // ---------------------------------------------------------------------------
@@ -1128,4 +1154,184 @@ func TestJWKSKeySource_Fetch_TooManyKeys_Errors(t *testing.T) {
 
 	err = source.Refresh(context.Background())
 	require.Error(t, err, "a JWKS with more than maxJWKSKeys RSA keys must be rejected")
+}
+
+// ---------------------------------------------------------------------------
+// FIX N1: enforce the transport policy on redirect targets (CWE-319)
+// ---------------------------------------------------------------------------
+
+// redirectingRoundTripper serves a 302 from the initial JWKS URL to a plaintext
+// non-loopback attacker URL, and (were the client to follow it) serves ATTACKER JWKS
+// from that target. attackerHits records whether the attacker target was ever fetched,
+// so a test can prove the redirect-policy enforcement blocked the hop rather than
+// relying on the target merely being unreachable.
+type redirectingRoundTripper struct {
+	attackerURL  string
+	attackerBody []byte
+	attackerHits *atomic.Int64
+}
+
+func (rt *redirectingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	newResp := func(status int, hdr http.Header, body []byte) *http.Response {
+		if hdr == nil {
+			hdr = make(http.Header)
+		}
+
+		return &http.Response{
+			StatusCode: status,
+			Header:     hdr,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Request:    req,
+		}
+	}
+
+	if req.URL.String() == rt.attackerURL {
+		rt.attackerHits.Add(1)
+
+		return newResp(http.StatusOK, nil, rt.attackerBody), nil
+	}
+
+	h := make(http.Header)
+	h.Set("Location", rt.attackerURL)
+
+	return newResp(http.StatusFound, h, nil), nil
+}
+
+// (a) An https (policy-compliant) JWKS URL that 302-redirects to a plaintext
+// non-loopback target must have the SAME fail-closed transport policy enforced on the
+// redirect hop: the hop is blocked, the attacker endpoint is never fetched, and its
+// keys are never cached (CWE-319 — plaintext response cached as a trust root).
+func TestJWKSKeySource_Fetch_RedirectToPlaintextNonLoopback_BlockedAndNotCached(t *testing.T) {
+	t.Parallel()
+
+	_, attackerPub := pubKeyOf(t)
+	attackerBody := jwksJSON(t, "cert-built-in", attackerPub)
+
+	var attackerHits atomic.Int64
+
+	rt := &redirectingRoundTripper{
+		attackerURL:  "http://evil.example.com/jwks",
+		attackerBody: attackerBody,
+		attackerHits: &attackerHits,
+	}
+
+	// Seed a known-good bootstrap key so we can prove the cache is NOT replaced by the
+	// attacker's redirected keys.
+	goodPriv, goodPub := pubKeyOf(t)
+	bootstrapPEM := pubPEMOf(t, goodPriv)
+
+	source, err := newJWKSKeySource(JWKSConfig{
+		URL:          "https://idp.internal/.well-known/jwks",
+		HTTPClient:   &http.Client{Transport: rt},
+		BootstrapPEM: []byte(bootstrapPEM),
+	})
+	require.NoError(t, err)
+
+	err = source.Refresh(context.Background())
+	require.Error(t, err, "a redirect from https to a plaintext non-loopback target must be blocked, not followed")
+	assert.Equal(t, int64(0), attackerHits.Load(), "the attacker endpoint must never be fetched")
+
+	keys := source.Keys(context.Background())
+	require.Len(t, keys, 1, "the cache must still hold only the bootstrap key")
+	assert.Equal(t, goodPub, keys[0], "the attacker's redirected keys must NOT be cached")
+}
+
+// (b) A policy-COMPLIANT redirect hop (loopback http -> loopback http) must still be
+// followed: the redirect enforcement rejects only policy-violating hops.
+func TestJWKSKeySource_Fetch_LoopbackToLoopbackRedirect_Allowed(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/keys", http.StatusFound) // relative -> same loopback host
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	})
+
+	srv := httptest.NewServer(mux) // http://127.0.0.1:port (loopback)
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL + "/jwks", HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	require.NoError(t, source.Refresh(context.Background()),
+		"a loopback->loopback http redirect is policy-compliant and must be followed")
+	assert.Equal(t, []*rsa.PublicKey{pub}, source.Keys(context.Background()))
+}
+
+// ---------------------------------------------------------------------------
+// FIX N3: the forced-refresh cooldown claim must be atomic
+// ---------------------------------------------------------------------------
+
+// countingBodyRoundTripper serves a fixed JWKS body and counts every fetch. Each call
+// completes IMMEDIATELY and independently, so concurrent forced refreshes do NOT share
+// a single-flight window (single-flight only collapses OVERLAPPING calls). That isolates
+// the cooldown claim: only an atomic claim can bound N concurrent forced refreshes to a
+// single upstream fetch per window.
+type countingBodyRoundTripper struct {
+	hits *atomic.Int64
+	body []byte
+}
+
+func (rt *countingBodyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.hits.Add(1)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(rt.body)),
+		Request:    req,
+	}, nil
+}
+
+// N concurrent forced Refresh calls within one cooldown window must collapse to exactly
+// ONE upstream fetch. The load/check/store sequence was not atomic: two callers could
+// both read lastForced, both pass the gate, and both start a fetch when their
+// single-flight windows did not overlap. A CompareAndSwap claim serializes the window so
+// exactly one caller fetches and the rest serve stale (return nil). Deterministic: a
+// fixed clock pins all callers to the same window; the fast transport keeps flights
+// non-overlapping. No sleeps.
+func TestVerify_SourcePath_ConcurrentForcedRefresh_AtMostOneFetchPerWindow(t *testing.T) {
+	t.Parallel()
+
+	_, serverPub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", serverPub)
+
+	var hits atomic.Int64
+
+	source, err := newJWKSKeySource(JWKSConfig{
+		URL:                   "https://idp.internal/jwks",
+		HTTPClient:            &http.Client{Transport: &countingBodyRoundTripper{hits: &hits, body: body}},
+		ForcedRefreshCooldown: time.Minute,
+	})
+	require.NoError(t, err)
+
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	source.now = clock.Now
+
+	const n = 64
+
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	wg.Add(n)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+			<-start // release all at once to maximize the concurrent claim race
+			_ = source.Refresh(context.Background())
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), hits.Load(),
+		"N concurrent forced refreshes in one cooldown window must collapse to exactly ONE upstream fetch")
 }

--- a/auth/middleware/keysource_test.go
+++ b/auth/middleware/keysource_test.go
@@ -1,0 +1,898 @@
+package middleware
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/MicahParks/jwkset"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// pubKeyOf returns the RSA public half of a generated key pair (the form a
+// KeySource yields).
+func pubKeyOf(t *testing.T) (*rsa.PrivateKey, *rsa.PublicKey) {
+	t.Helper()
+
+	priv, _ := newTestRSAKeyPEM(t)
+
+	return priv, &priv.PublicKey
+}
+
+// pubPEMOf returns the PKIX PEM encoding of a private key's public half — the
+// form a bootstrap seed and NewM2MAuthenticator both accept.
+func pubPEMOf(t *testing.T, priv *rsa.PrivateKey) string {
+	t.Helper()
+
+	der, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+// jwksJSON renders one or more RSA public keys as a standard JWKS-JSON document
+// (RFC 7517), all sharing the given kid — mirroring how Casdoor republishes a
+// regenerated keypair under the SAME kid (cert-built-in).
+func jwksJSON(t *testing.T, kid string, pubs ...*rsa.PublicKey) []byte {
+	t.Helper()
+
+	marshals := make([]jwkset.JWKMarshal, 0, len(pubs))
+
+	for _, pub := range pubs {
+		jwk, err := jwkset.NewJWKFromKey(pub, jwkset.JWKOptions{
+			Metadata: jwkset.JWKMetadataOptions{KID: kid, ALG: jwkset.AlgRS256, USE: jwkset.UseSig},
+		})
+		require.NoError(t, err)
+
+		marshals = append(marshals, jwk.Marshal())
+	}
+
+	data, err := json.Marshal(jwkset.JWKSMarshal{Keys: marshals})
+	require.NoError(t, err)
+
+	return data
+}
+
+// fakeKeySource is a fully in-memory KeySource double for exercising the
+// M2MAuthenticator retry logic deterministically (no HTTP, no goroutine). It
+// records how many times Keys and Refresh were called so tests can assert the
+// exact number of forced refreshes / retries.
+type fakeKeySource struct {
+	mu           sync.Mutex
+	keys         []*rsa.PublicKey
+	onRefresh    func() []*rsa.PublicKey // when set, replaces keys on Refresh
+	refreshErr   error
+	keysCount    int
+	refreshCount int
+}
+
+func (f *fakeKeySource) Keys(_ context.Context) []*rsa.PublicKey {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.keysCount++
+
+	return f.keys
+}
+
+func (f *fakeKeySource) Refresh(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.refreshCount++
+
+	if f.refreshErr != nil {
+		return f.refreshErr
+	}
+
+	if f.onRefresh != nil {
+		f.keys = f.onRefresh()
+	}
+
+	return nil
+}
+
+func (f *fakeKeySource) Close() error { return nil }
+
+func (f *fakeKeySource) refreshes() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.refreshCount
+}
+
+// fakeClock is a controllable monotonic clock for deterministic cooldown tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.t = c.t.Add(d)
+}
+
+func newSourceAuthenticator(t *testing.T, source KeySource, issuer string) *M2MAuthenticator {
+	t.Helper()
+
+	logger := log.Logger(&testLogger{})
+
+	m, err := NewM2MAuthenticatorWithKeySource(source, issuer, true, &logger)
+	require.NoError(t, err)
+
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// StaticKeySource
+// ---------------------------------------------------------------------------
+
+func TestStaticKeySource_ReturnsKeys_RefreshNoop(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+
+	src := StaticKeySource(pub)
+
+	require.Equal(t, []*rsa.PublicKey{pub}, src.Keys(context.Background()))
+	require.NoError(t, src.Refresh(context.Background()))
+	require.NoError(t, src.Close())
+	require.Equal(t, []*rsa.PublicKey{pub}, src.Keys(context.Background()))
+}
+
+// ---------------------------------------------------------------------------
+// M2MAuthenticator with KeySource: happy path
+// ---------------------------------------------------------------------------
+
+func TestVerify_SourcePath_ValidToken_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	token := signRS256(t, priv, applicationClaims())
+
+	claims, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "admin/3a09ac44-1faf-4e66-843c-5152b09b19dc", claims["sub"])
+	assert.Equal(t, 0, source.refreshes(), "a token that verifies on the first try must not trigger a refresh")
+}
+
+// ---------------------------------------------------------------------------
+// THE gotcha: stable-kid key rotation -> refresh on signature failure
+// ---------------------------------------------------------------------------
+
+func TestVerify_SourcePath_StaleKey_RefreshesOnceAndRetries(t *testing.T) {
+	t.Parallel()
+
+	// Cache holds the OLD key; the token is signed by the NEW key (same kid).
+	_, oldPub := pubKeyOf(t)
+	newPriv, newPub := pubKeyOf(t)
+
+	source := &fakeKeySource{
+		keys:      []*rsa.PublicKey{oldPub},
+		onRefresh: func() []*rsa.PublicKey { return []*rsa.PublicKey{newPub} },
+	}
+	m := newSourceAuthenticator(t, source, "")
+
+	token := signRS256(t, newPriv, applicationClaims())
+
+	claims, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.NoError(t, err, "after the forced refresh pulls the new key, verification must succeed")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "admin/3a09ac44-1faf-4e66-843c-5152b09b19dc", claims["sub"])
+	assert.Equal(t, 1, source.refreshes(), "exactly ONE forced refresh on the signature failure")
+}
+
+// A signature failure that persists after the refresh must still fail closed and
+// must refresh exactly ONCE — never loop.
+func TestVerify_SourcePath_PersistentBadSignature_RefreshesOnce_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	attackerPriv, _ := pubKeyOf(t)
+	_, serverPub := pubKeyOf(t)
+
+	// Refresh keeps returning the same (wrong) server key; the attacker token never verifies.
+	source := &fakeKeySource{
+		keys:      []*rsa.PublicKey{serverPub},
+		onRefresh: func() []*rsa.PublicKey { return []*rsa.PublicKey{serverPub} },
+	}
+	m := newSourceAuthenticator(t, source, "")
+
+	token := signRS256(t, attackerPriv, applicationClaims())
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 1, source.refreshes(), "retry is bounded to ONE forced refresh, never a loop")
+}
+
+// When the forced refresh itself fails, verification fails closed on the original
+// signature error (never falls open).
+func TestVerify_SourcePath_RefreshError_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	_, oldPub := pubKeyOf(t)
+	newPriv, _ := pubKeyOf(t)
+
+	source := &fakeKeySource{
+		keys:       []*rsa.PublicKey{oldPub},
+		refreshErr: assert.AnError,
+	}
+	m := newSourceAuthenticator(t, source, "")
+
+	token := signRS256(t, newPriv, applicationClaims())
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 1, source.refreshes(), "one refresh was attempted; its failure must not fall open")
+}
+
+// ---------------------------------------------------------------------------
+// fail-closed: non-key failures must NOT trigger a refresh loop
+// ---------------------------------------------------------------------------
+
+func TestVerify_SourcePath_AlgConfusionHS256_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	// RS/HS confusion: forge an HS256 token. WithValidMethods reports this as
+	// ErrTokenSignatureInvalid too, but its header alg is HS256, so it must NOT
+	// be mistaken for key staleness and must NOT refresh.
+	forged := jwt.NewWithClaims(jwt.SigningMethodHS256, applicationClaims())
+
+	signed, err := forged.SignedString([]byte(pubPEMOf(t, priv)))
+	require.NoError(t, err)
+
+	_, statusCode, verr := m.verify(context.Background(), noopSpan(), signed)
+
+	require.Error(t, verr)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 0, source.refreshes(), "alg-confusion is not key staleness: no refresh")
+}
+
+func TestVerify_SourcePath_AlgNone_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	unsigned := jwt.NewWithClaims(jwt.SigningMethodNone, applicationClaims())
+
+	signed, err := unsigned.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	_, statusCode, verr := m.verify(context.Background(), noopSpan(), signed)
+
+	require.Error(t, verr)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 0, source.refreshes(), "alg=none is not key staleness: no refresh")
+}
+
+func TestVerify_SourcePath_Expired_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	claims := applicationClaims()
+	claims["exp"] = float64(time.Now().Add(-time.Hour).Unix())
+
+	token := signRS256(t, priv, claims)
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 0, source.refreshes(), "an expired (validly signed) token is not key staleness: no refresh")
+}
+
+func TestVerify_SourcePath_WrongIssuer_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	const issuer = "http://expected-issuer:8000"
+
+	priv, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, issuer)
+
+	claims := applicationClaims()
+	claims["iss"] = "http://attacker-issuer:8000"
+
+	token := signRS256(t, priv, claims)
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 0, source.refreshes(), "a wrong-issuer (validly signed) token is not key staleness: no refresh")
+}
+
+func TestVerify_SourcePath_EmptySub_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	claims := applicationClaims()
+	delete(claims, "sub")
+
+	token := signRS256(t, priv, claims)
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 0, source.refreshes(), "signature is valid; an empty sub is an app-claim failure, not key staleness")
+}
+
+func TestVerify_SourcePath_NonApplicationType_Forbidden_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	claims := applicationClaims()
+	claims["type"] = "normal-user"
+
+	token := signRS256(t, priv, claims)
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusForbidden, statusCode)
+	assert.Equal(t, 0, source.refreshes(), "signature is valid; a wrong token type is not key staleness")
+}
+
+// ---------------------------------------------------------------------------
+// JWKSKeySource: real HTTP fetch + parse
+// ---------------------------------------------------------------------------
+
+func TestJWKSKeySource_Refresh_FetchedKeyVerifies(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	require.NoError(t, source.Refresh(context.Background()))
+
+	m := newSourceAuthenticator(t, source, "")
+	token := signRS256(t, priv, applicationClaims())
+
+	_, statusCode, verr := m.verify(context.Background(), noopSpan(), token)
+
+	require.NoError(t, verr)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, []*rsa.PublicKey{pub}, source.Keys(context.Background()))
+}
+
+// serve-stale (fail-open availability): the endpoint is down, but the bootstrap
+// seed keeps verifying.
+func TestJWKSKeySource_ServeStale_EndpointDown(t *testing.T) {
+	t.Parallel()
+
+	priv, _ := pubKeyOf(t)
+
+	// Seed from a bootstrap PEM; the live endpoint always 500s.
+	bootstrapPEM := pubPEMOf(t, priv)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{
+		URL:          srv.URL,
+		HTTPClient:   srv.Client(),
+		BootstrapPEM: []byte(bootstrapPEM),
+	})
+	require.NoError(t, err)
+
+	// The forced refresh fails (500) but the seeded keys are preserved (serve-stale).
+	require.Error(t, source.Refresh(context.Background()))
+
+	keys := source.Keys(context.Background())
+	require.Len(t, keys, 1, "the last-good (bootstrap) key must still be served when the endpoint is down")
+
+	m := newSourceAuthenticator(t, source, "")
+	token := signRS256(t, priv, applicationClaims())
+
+	_, statusCode, verr := m.verify(context.Background(), noopSpan(), token)
+
+	require.NoError(t, verr, "a token signed by the still-cached key must verify despite the endpoint being down")
+	assert.Equal(t, http.StatusOK, statusCode)
+}
+
+// single-flight: N concurrent (un-gated) refreshes collapse to exactly ONE HTTP
+// fetch. Deterministic via a counting barrier — the handler blocks until all N
+// goroutines have entered, so the single leader cannot complete before the
+// followers join its in-flight window. No timing sleeps.
+func TestJWKSKeySource_SingleFlight_ConcurrentRefresh_OneFetch(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	const n = 24
+
+	var hits atomic.Int64
+
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		<-release // hold the (single) leader open until every goroutine has joined
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	entered := make(chan struct{}, n)
+
+	var wg sync.WaitGroup
+
+	wg.Add(n)
+
+	for range n {
+		go func() {
+			defer wg.Done()
+			entered <- struct{}{}
+			_ = source.refreshNow(context.Background())
+		}()
+	}
+
+	// Barrier: wait until all N goroutines are in the refresh path, THEN release the
+	// leader's handler. The leader is blocked on <-release, so it cannot return and
+	// let a straggler start a second fetch.
+	for range n {
+		<-entered
+	}
+
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int64(1), hits.Load(), "concurrent refreshes must collapse to a single HTTP fetch")
+}
+
+// bootstrap seed: constructing with an unreachable endpoint still makes the
+// seeded key available immediately (lazy first live fetch, non-blocking).
+func TestJWKSKeySource_BootstrapSeed_UnreachableEndpoint(t *testing.T) {
+	t.Parallel()
+
+	priv, _ := pubKeyOf(t)
+	bootstrapPEM := pubPEMOf(t, priv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// A closed/unreachable endpoint: construction must not block and Keys() must
+	// return the seed immediately.
+	source, err := NewJWKSKeySource(JWKSConfig{
+		URL:             "http://127.0.0.1:0/jwks",
+		BootstrapPEM:    []byte(bootstrapPEM),
+		RefreshInterval: time.Hour,
+		Ctx:             ctx,
+	})
+	require.NoError(t, err)
+
+	keys := source.Keys(context.Background())
+	require.Len(t, keys, 1)
+
+	m := newSourceAuthenticator(t, source, "")
+	token := signRS256(t, priv, applicationClaims())
+
+	_, statusCode, verr := m.verify(context.Background(), noopSpan(), token)
+
+	require.NoError(t, verr, "the seeded bootstrap key must verify even though the endpoint is unreachable")
+	assert.Equal(t, http.StatusOK, statusCode)
+}
+
+// ---------------------------------------------------------------------------
+// Forced-refresh cooldown (refresh-amplification DoS guard)
+// ---------------------------------------------------------------------------
+
+// A burst of DISTINCT bad-signature RS256 tokens must not drive one upstream fetch
+// per request. Single-flight only collapses CONCURRENT calls; the cooldown bounds
+// the SEQUENTIAL stream to one upstream fetch per window.
+func TestVerify_SourcePath_ForcedRefreshCooldown_BoundsUpstreamFetches(t *testing.T) {
+	t.Parallel()
+
+	_, serverPub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", serverPub)
+
+	var hits atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	source, err := newJWKSKeySource(JWKSConfig{
+		URL:                   srv.URL,
+		HTTPClient:            srv.Client(),
+		ForcedRefreshCooldown: time.Minute,
+	})
+	require.NoError(t, err)
+
+	source.now = clock.Now
+
+	m := newSourceAuthenticator(t, source, "")
+
+	const n = 20
+
+	for range n {
+		// Each token is DISTINCT (a different attacker key) so single-flight cannot
+		// collapse them; only the cooldown bounds the upstream calls.
+		attackerPriv, _ := pubKeyOf(t)
+
+		token := signRS256(t, attackerPriv, applicationClaims())
+
+		_, statusCode, verr := m.verify(context.Background(), noopSpan(), token)
+		require.Error(t, verr)
+		assert.Equal(t, http.StatusUnauthorized, statusCode)
+	}
+
+	assert.Equal(t, int64(1), hits.Load(), "a burst of distinct bad tokens must collapse to ONE upstream fetch within the cooldown")
+
+	// Once the cooldown window elapses, the forced path may hit upstream again.
+	clock.Advance(2 * time.Minute)
+
+	attackerPriv, _ := pubKeyOf(t)
+	_, _, _ = m.verify(context.Background(), noopSpan(), signRS256(t, attackerPriv, applicationClaims()))
+
+	assert.Equal(t, int64(2), hits.Load(), "a bad token after the cooldown window triggers exactly one more fetch")
+}
+
+// The cooldown must NOT block a legitimate rotation: when no forced refresh has run
+// recently (lastForced == 0, warmed by the background loop), the first bad token
+// after a rotation refreshes promptly and verifies.
+func TestVerify_SourcePath_Cooldown_DoesNotBlockLegitRotation(t *testing.T) {
+	t.Parallel()
+
+	_, oldPub := pubKeyOf(t)
+	newPriv, newPub := pubKeyOf(t)
+
+	var serveNew atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if serveNew.Load() {
+			_, _ = w.Write(jwksJSON(t, "cert-built-in", newPub))
+
+			return
+		}
+
+		_, _ = w.Write(jwksJSON(t, "cert-built-in", oldPub))
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{
+		URL:                   srv.URL,
+		HTTPClient:            srv.Client(),
+		ForcedRefreshCooldown: time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Warm the cache via the UN-gated background path (does not consume a forced
+	// slot), so lastForced stays 0 — mirroring real steady-state operation.
+	require.NoError(t, source.refreshNow(context.Background()))
+
+	// Rotation happens.
+	serveNew.Store(true)
+
+	m := newSourceAuthenticator(t, source, "")
+	token := signRS256(t, newPriv, applicationClaims())
+
+	_, statusCode, verr := m.verify(context.Background(), noopSpan(), token)
+
+	require.NoError(t, verr, "a legit rotated-key token refreshes and verifies on the first attempt; cooldown must not block the good path")
+	assert.Equal(t, http.StatusOK, statusCode)
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle: Close stops the background refresher
+// ---------------------------------------------------------------------------
+
+func TestJWKSKeySource_Close_StopsBackgroundRefresher(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	var hits atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := NewJWKSKeySource(JWKSConfig{
+		URL:             srv.URL,
+		HTTPClient:      srv.Client(),
+		RefreshInterval: 15 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	// The background refresher is running: it fetches repeatedly on the TTL.
+	require.Eventually(t, func() bool { return hits.Load() >= 2 }, 2*time.Second, 5*time.Millisecond)
+
+	require.NoError(t, source.Close())
+
+	// After Close, let any in-flight fetch settle, then assert fetches have stopped.
+	time.Sleep(60 * time.Millisecond)
+	settled := hits.Load()
+
+	time.Sleep(90 * time.Millisecond) // ~6 refresh intervals
+
+	assert.Equal(t, settled, hits.Load(), "no JWKS fetches after Close: the background refresher stopped")
+}
+
+// ---------------------------------------------------------------------------
+// parseJWKSKeysAndKIDs: use/alg filtering (keep omitted, drop explicit-mismatch)
+// ---------------------------------------------------------------------------
+
+func TestParseJWKSPublicKeys_UseEncKeyDropped(t *testing.T) {
+	t.Parallel()
+
+	_, rsaPub := pubKeyOf(t)
+
+	jwk, err := jwkset.NewJWKFromKey(rsaPub, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{KID: "enc-key", USE: jwkset.UseEnc},
+	})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(jwkset.JWKSMarshal{Keys: []jwkset.JWKMarshal{jwk.Marshal()}})
+	require.NoError(t, err)
+
+	keys, _, err := parseJWKSKeysAndKIDs(data)
+	require.NoError(t, err)
+	assert.Empty(t, keys, "an RSA key explicitly marked use=enc is not a signature key and must be dropped")
+}
+
+func TestParseJWKSPublicKeys_NonRS256AlgDropped(t *testing.T) {
+	t.Parallel()
+
+	_, rsaPub := pubKeyOf(t)
+
+	jwk, err := jwkset.NewJWKFromKey(rsaPub, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{KID: "rs512", ALG: jwkset.AlgRS512},
+	})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(jwkset.JWKSMarshal{Keys: []jwkset.JWKMarshal{jwk.Marshal()}})
+	require.NoError(t, err)
+
+	keys, _, err := parseJWKSKeysAndKIDs(data)
+	require.NoError(t, err)
+	assert.Empty(t, keys, "a key with an explicit non-RS256 alg must be dropped")
+}
+
+func TestParseJWKSPublicKeys_OmittedUseAndAlgKept(t *testing.T) {
+	t.Parallel()
+
+	_, rsaPub := pubKeyOf(t)
+
+	// Casdoor may publish keys without use/alg — those MUST be kept.
+	jwk, err := jwkset.NewJWKFromKey(rsaPub, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{KID: "cert-built-in"},
+	})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(jwkset.JWKSMarshal{Keys: []jwkset.JWKMarshal{jwk.Marshal()}})
+	require.NoError(t, err)
+
+	keys, _, err := parseJWKSKeysAndKIDs(data)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "a key that omits use/alg must be kept")
+	assert.Equal(t, rsaPub, keys[0])
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+func TestNewJWKSKeySource_EmptyURL_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewJWKSKeySource(JWKSConfig{URL: "  "})
+	require.Error(t, err)
+}
+
+func TestNewJWKSKeySource_BadBootstrapPEM_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewJWKSKeySource(JWKSConfig{URL: "http://example/jwks", BootstrapPEM: []byte("not-a-pem")})
+	require.Error(t, err)
+}
+
+func TestNewM2MAuthenticatorWithKeySource_EnabledRequiresSource(t *testing.T) {
+	t.Parallel()
+
+	logger := log.Logger(&testLogger{})
+
+	_, err := NewM2MAuthenticatorWithKeySource(nil, "", true, &logger)
+	require.Error(t, err)
+}
+
+func TestNewM2MAuthenticatorWithKeySource_DisabledAllowsNilSource(t *testing.T) {
+	t.Parallel()
+
+	logger := log.Logger(&testLogger{})
+
+	m, err := NewM2MAuthenticatorWithKeySource(nil, "", false, &logger)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.False(t, m.enabled)
+}
+
+// ---------------------------------------------------------------------------
+// parseJWKSKeysAndKIDs: JWKS-JSON -> RSA keys (error + filter branches)
+// ---------------------------------------------------------------------------
+
+func TestParseJWKSPublicKeys_InvalidJSON_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseJWKSKeysAndKIDs([]byte("{not json"))
+	require.Error(t, err)
+}
+
+func TestParseJWKSPublicKeys_EmptyKeySet_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	keys, _, err := parseJWKSKeysAndKIDs([]byte(`{"keys":[]}`))
+	require.NoError(t, err)
+	assert.Empty(t, keys)
+}
+
+func TestParseJWKSPublicKeys_NonRSAKeyIgnored(t *testing.T) {
+	t.Parallel()
+
+	// An EC (P-256) JWK is valid JWKS-JSON but not RS256; it must be filtered out,
+	// leaving only the RSA key (RS256-only verification).
+	ecPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	ecJWK, err := jwkset.NewJWKFromKey(&ecPriv.PublicKey, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{KID: "ec-key"},
+	})
+	require.NoError(t, err)
+
+	_, rsaPub := pubKeyOf(t)
+
+	rsaJWK, err := jwkset.NewJWKFromKey(rsaPub, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{KID: "cert-built-in", ALG: jwkset.AlgRS256, USE: jwkset.UseSig},
+	})
+	require.NoError(t, err)
+
+	data, err := json.Marshal(jwkset.JWKSMarshal{Keys: []jwkset.JWKMarshal{ecJWK.Marshal(), rsaJWK.Marshal()}})
+	require.NoError(t, err)
+
+	keys, _, err := parseJWKSKeysAndKIDs(data)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "only the RSA key survives the filter")
+	assert.Equal(t, rsaPub, keys[0])
+}
+
+// ---------------------------------------------------------------------------
+// JWKSKeySource fetch error branches
+// ---------------------------------------------------------------------------
+
+func TestJWKSKeySource_Refresh_EmptyJWKS_Errors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	err = source.Refresh(context.Background())
+	require.Error(t, err, "a JWKS with no RSA keys is a refresh failure, not a silent empty key set")
+}
+
+func TestJWKSKeySource_Refresh_MalformedJSON_Errors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("{not-json"))
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	require.Error(t, source.Refresh(context.Background()))
+}
+
+// ---------------------------------------------------------------------------
+// source-path failure classification: malformed + empty-cache branches
+// ---------------------------------------------------------------------------
+
+func TestVerify_SourcePath_MalformedToken_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), "not-a-jwt")
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 0, source.refreshes(), "a malformed token is not key staleness: no refresh")
+}
+
+func TestVerify_SourcePath_EmptyCache_RefreshesOnce(t *testing.T) {
+	t.Parallel()
+
+	// Cache is empty (bootstrap absent, first fetch pending); verifyToken fails with
+	// "no key". That IS a key-availability failure, so exactly one forced refresh
+	// fires. Here the refresh yields nothing, so it still fails closed.
+	priv, _ := pubKeyOf(t)
+	source := &fakeKeySource{keys: nil}
+	m := newSourceAuthenticator(t, source, "")
+
+	token := signRS256(t, priv, applicationClaims())
+
+	_, statusCode, err := m.verify(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 1, source.refreshes(), "an empty key cache warrants exactly one forced refresh")
+}

--- a/auth/middleware/keysource_test.go
+++ b/auth/middleware/keysource_test.go
@@ -672,13 +672,16 @@ func TestJWKSKeySource_Close_StopsBackgroundRefresher(t *testing.T) {
 
 	require.NoError(t, source.Close())
 
-	// After Close, let any in-flight fetch settle, then assert fetches have stopped.
-	time.Sleep(60 * time.Millisecond)
-	settled := hits.Load()
+	// After Close the background loop returns on ctx cancellation, so it schedules no
+	// new fetches. At most ONE fetch may already be in flight (the fetch is detached
+	// from the loop ctx and completes rather than being cancelled), so allow that one
+	// to settle and assert the count never advances beyond it — deterministically,
+	// with no fixed sleeps.
+	before := hits.Load()
 
-	time.Sleep(90 * time.Millisecond) // ~6 refresh intervals
-
-	assert.Equal(t, settled, hits.Load(), "no JWKS fetches after Close: the background refresher stopped")
+	require.Never(t, func() bool { return hits.Load() > before+1 },
+		200*time.Millisecond, 10*time.Millisecond,
+		"no new JWKS fetches after Close: the background refresher stopped")
 }
 
 // ---------------------------------------------------------------------------
@@ -895,4 +898,234 @@ func TestVerify_SourcePath_EmptyCache_RefreshesOnce(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, http.StatusUnauthorized, statusCode)
 	assert.Equal(t, 1, source.refreshes(), "an empty key cache warrants exactly one forced refresh")
+}
+
+// ---------------------------------------------------------------------------
+// FIX 1: the JWKS fetch is detached from the caller's request-scoped ctx
+// ---------------------------------------------------------------------------
+
+// capturingLogger records the level + message of every Log call so a test can
+// assert that a specific WARN was emitted (e.g. the plaintext-HTTP warning).
+type capturingLogger struct {
+	mu   sync.Mutex
+	lvls []log.Level
+	msgs []string
+}
+
+func (c *capturingLogger) Log(_ context.Context, lvl log.Level, msg string, _ ...log.Field) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.lvls = append(c.lvls, lvl)
+	c.msgs = append(c.msgs, msg)
+}
+
+func (c *capturingLogger) With(_ ...log.Field) log.Logger { return c }
+func (c *capturingLogger) WithGroup(_ string) log.Logger  { return c }
+func (c *capturingLogger) Enabled(_ log.Level) bool       { return true }
+func (c *capturingLogger) Sync(_ context.Context) error   { return nil }
+
+func (c *capturingLogger) warnCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	n := 0
+
+	for _, l := range c.lvls {
+		if l == log.LevelWarn {
+			n++
+		}
+	}
+
+	return n
+}
+
+// cancelRoundTripper is a fake transport that always returns context.Canceled,
+// so a fetch through it yields an error that errors.Is(context.Canceled).
+type cancelRoundTripper struct {
+	hits *atomic.Int64
+}
+
+func (rt cancelRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	rt.hits.Add(1)
+
+	return nil, context.Canceled
+}
+
+// A caller ctx that is already cancelled must NOT abort the shared single-flight
+// fetch that fills the process-lifetime cache: the fetch still completes and caches.
+func TestJWKSKeySource_Refresh_CancelledCallerCtx_StillFetchesAndCaches(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel BEFORE the fetch: the source fetch must ignore this
+
+	require.NoError(t, source.Refresh(ctx), "a cancelled caller ctx must not abort the shared JWKS fetch")
+	assert.Equal(t, []*rsa.PublicKey{pub}, source.Keys(context.Background()),
+		"the detached fetch must still populate the cache")
+}
+
+// A forced refresh that fails with context.Canceled must RELEASE the cooldown
+// window (a genuinely-cancelled attempt is not the amplification case), so a
+// subsequent forced Refresh within the cooldown is NOT gated.
+func TestJWKSKeySource_Refresh_ContextCanceled_ReleasesCooldownWindow(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int64
+
+	source, err := newJWKSKeySource(JWKSConfig{
+		URL:                   "https://example.com/jwks", // https: passes URL validation; transport is faked
+		HTTPClient:            &http.Client{Transport: cancelRoundTripper{hits: &hits}},
+		ForcedRefreshCooldown: time.Minute,
+	})
+	require.NoError(t, err)
+
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	source.now = clock.Now
+
+	// First forced refresh is cancelled -> releases the window.
+	require.ErrorIs(t, source.Refresh(context.Background()), context.Canceled)
+	require.Equal(t, int64(1), hits.Load())
+
+	// WITHIN the cooldown (clock not advanced): a normal fetch-failure would stay
+	// gated, but a released window means this attempt hits upstream again.
+	require.ErrorIs(t, source.Refresh(context.Background()), context.Canceled)
+	assert.Equal(t, int64(2), hits.Load(),
+		"a context.Canceled forced refresh must release the cooldown window")
+}
+
+// ---------------------------------------------------------------------------
+// FIX 2: require https by default, loopback http carve-out, explicit opt-in
+// ---------------------------------------------------------------------------
+
+func TestNewJWKSKeySource_HTTPSURL_OK(t *testing.T) {
+	t.Parallel()
+
+	_, err := newJWKSKeySource(JWKSConfig{URL: "https://casdoor.example.com/.well-known/jwks"})
+	require.NoError(t, err)
+}
+
+func TestNewJWKSKeySource_LoopbackHTTP_OKWithoutFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"ipv4_loopback", "http://127.0.0.1:8000/jwks"},
+		{"ipv4_loopback_range", "http://127.0.0.5:8000/jwks"},
+		{"ipv6_loopback", "http://[::1]:8000/jwks"},
+		{"localhost", "http://localhost:8000/jwks"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newJWKSKeySource(JWKSConfig{URL: tt.url})
+			require.NoError(t, err, "loopback http must be allowed without AllowInsecureURL")
+		})
+	}
+}
+
+func TestNewJWKSKeySource_NonLoopbackHTTP_RejectedWithoutFlag(t *testing.T) {
+	t.Parallel()
+
+	_, err := newJWKSKeySource(JWKSConfig{URL: "http://casdoor.example.com/jwks"})
+	require.Error(t, err, "plaintext http against a non-loopback host must fail closed without AllowInsecureURL")
+}
+
+func TestNewJWKSKeySource_NonLoopbackHTTP_AllowedWithFlag_Warns(t *testing.T) {
+	t.Parallel()
+
+	cap := &capturingLogger{}
+	logger := log.Logger(cap)
+
+	_, err := newJWKSKeySource(JWKSConfig{
+		URL:              "http://casdoor.example.com/jwks",
+		AllowInsecureURL: true,
+		Logger:           logger,
+	})
+	require.NoError(t, err, "AllowInsecureURL permits plaintext http against a non-loopback host")
+	assert.GreaterOrEqual(t, cap.warnCount(), 1, "an insecure-URL opt-in must emit a loud WARN at construction")
+}
+
+func TestNewJWKSKeySource_InvalidScheme_Rejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"ftp", "ftp://example.com/jwks"},
+		{"relative", "/relative/jwks"},
+		{"no_scheme", "example.com/jwks"},
+		{"unparseable", "http://[::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := newJWKSKeySource(JWKSConfig{URL: tt.url})
+			require.Error(t, err, "a non-http(s) / unparseable URL must be rejected")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FIX 4: bound the response size (detect truncation) and the key count
+// ---------------------------------------------------------------------------
+
+func TestJWKSKeySource_Fetch_ResponseTooLarge_Errors(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(make([]byte, maxJWKSResponseBytes+64)) // one chunk past the cap
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	err = source.Refresh(context.Background())
+	require.Error(t, err, "an over-cap response must be an explicit size error, not a silent truncation")
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+func TestJWKSKeySource_Fetch_TooManyKeys_Errors(t *testing.T) {
+	t.Parallel()
+
+	// maxJWKSKeys+1 entries (all the same key is fine: the guard bounds COUNT, and
+	// verifyToken tries keys until one matches, so an oversized set multiplies work).
+	_, pub := pubKeyOf(t)
+
+	pubs := make([]*rsa.PublicKey, maxJWKSKeys+1)
+	for i := range pubs {
+		pubs[i] = pub
+	}
+
+	body := jwksJSON(t, "cert-built-in", pubs...)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	err = source.Refresh(context.Background())
+	require.Error(t, err, "a JWKS with more than maxJWKSKeys RSA keys must be rejected")
 }

--- a/auth/middleware/keysource_test.go
+++ b/auth/middleware/keysource_test.go
@@ -1263,6 +1263,32 @@ func TestJWKSKeySource_Fetch_LoopbackToLoopbackRedirect_Allowed(t *testing.T) {
 	assert.Equal(t, []*rsa.PublicKey{pub}, source.Keys(context.Background()))
 }
 
+// A custom CheckRedirect replaces net/http's default 10-hop cap, so an endpoint
+// that loops policy-compliant (loopback) redirects must still be stopped by our
+// explicit hop limit rather than running for the whole fetch timeout.
+func TestJWKSKeySource_Fetch_RedirectLoop_StoppedByHopLimit(t *testing.T) {
+	t.Parallel()
+
+	var hits int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/loop", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Redirect(w, r, "/loop", http.StatusFound) // loopback self-redirect: policy-compliant, infinite
+	})
+
+	srv := httptest.NewServer(mux) // http://127.0.0.1:port (loopback)
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL + "/loop", HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	rerr := source.Refresh(context.Background())
+	require.Error(t, rerr, "an infinite redirect loop must be stopped, not followed to the timeout")
+	assert.Contains(t, rerr.Error(), "redirects")
+	assert.LessOrEqual(t, hits, maxJWKSRedirects+1, "must stop at the hop cap, not loop unbounded")
+}
+
 // ---------------------------------------------------------------------------
 // FIX N3: the forced-refresh cooldown claim must be atomic
 // ---------------------------------------------------------------------------

--- a/auth/middleware/live_jwks_integration_test.go
+++ b/auth/middleware/live_jwks_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+// Live integration proof for PAM card #3755: verify that an M2M token minted by a
+// REAL Casdoor is accepted through the dynamic-JWKS path, and that a WRONG bootstrap
+// seed is recovered by fetching the live JWKS (the from-scratch cert-mismatch gotcha).
+//
+// Run against the local plugin-access-manager stack:
+//
+//	M2M_TOKEN="$(cat .../m2m.token)" \
+//	  go test -tags=integration -run TestLiveJWKS -v ./auth/middleware/
+//
+// JWKS_URL defaults to Casdoor's local endpoint; ISSUER must match the token's iss.
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+
+	return def
+}
+
+// wrongBootstrapPEM returns a PKIX PEM for a freshly generated, UNRELATED RSA public
+// key — guaranteed NOT to match Casdoor's signing key, so verification can only pass
+// if the live JWKS fetch actually happened.
+func wrongBootstrapPEM(t *testing.T) []byte {
+	t.Helper()
+
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+
+	der, err := x509.MarshalPKIXPublicKey(&k.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal pkix: %v", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+}
+
+func TestLiveJWKS_WrongBootstrapRecoveredByLiveFetch(t *testing.T) {
+	token := os.Getenv("M2M_TOKEN")
+	if token == "" {
+		t.Skip("M2M_TOKEN not set; skipping live integration test")
+	}
+
+	jwksURL := envOr("JWKS_URL", "http://localhost:8000/.well-known/jwks")
+	issuer := envOr("ISSUER", "http://plugin-auth-casdoor-backend:8000")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := log.Logger(&testLogger{})
+
+	source, err := NewJWKSKeySource(JWKSConfig{
+		URL:             jwksURL,
+		BootstrapPEM:    wrongBootstrapPEM(t), // deliberately WRONG seed
+		RefreshInterval: time.Minute,
+		Ctx:             ctx,
+		Logger:          logger,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSKeySource: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	m, err := NewM2MAuthenticatorWithKeySource(source, issuer, true, &logger)
+	if err != nil {
+		t.Fatalf("NewM2MAuthenticatorWithKeySource: %v", err)
+	}
+
+	// verify() forces a single JWKS refresh on the initial (wrong-seed) signature
+	// failure, pulls the LIVE Casdoor key, and retries — proving the whole path
+	// against a real IdP. A short retry loop tolerates the background lazy fetch
+	// racing ahead of the forced one; either way success REQUIRES the live fetch.
+	var (
+		claims     jwt.MapClaims
+		statusCode int
+		verr       error
+	)
+
+	for attempt := 0; attempt < 3; attempt++ {
+		claims, statusCode, verr = m.verify(ctx, noopSpan(), token)
+		if verr == nil {
+			break
+		}
+
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	if verr != nil {
+		t.Fatalf("live verify failed after retries: status=%d err=%v", statusCode, verr)
+	}
+
+	if statusCode != 200 {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+
+	if claims["type"] != "application" {
+		t.Fatalf("expected type=application, got %v", claims["type"])
+	}
+
+	t.Logf("LIVE VERIFY OK: status=%d iss=%v sub=%v type=%v",
+		statusCode, claims["iss"], claims["sub"], claims["type"])
+}
+
+// Control: WRONG bootstrap + UNREACHABLE JWKS URL must FAIL closed — proving the
+// success above is genuinely due to the live fetch, not an accidental match.
+func TestLiveJWKS_WrongBootstrapUnreachableFailsClosed(t *testing.T) {
+	token := os.Getenv("M2M_TOKEN")
+	if token == "" {
+		t.Skip("M2M_TOKEN not set; skipping live integration test")
+	}
+
+	issuer := envOr("ISSUER", "http://plugin-auth-casdoor-backend:8000")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := log.Logger(&testLogger{})
+
+	source, err := NewJWKSKeySource(JWKSConfig{
+		URL:             "http://127.0.0.1:1/.well-known/jwks", // unreachable
+		BootstrapPEM:    wrongBootstrapPEM(t),
+		RefreshInterval: time.Minute,
+		Ctx:             ctx,
+		Logger:          logger,
+	})
+	if err != nil {
+		t.Fatalf("NewJWKSKeySource: %v", err)
+	}
+	defer func() { _ = source.Close() }()
+
+	m, err := NewM2MAuthenticatorWithKeySource(source, issuer, true, &logger)
+	if err != nil {
+		t.Fatalf("NewM2MAuthenticatorWithKeySource: %v", err)
+	}
+
+	_, statusCode, verr := m.verify(ctx, noopSpan(), token)
+	if verr == nil {
+		t.Fatalf("expected fail-closed with wrong seed + unreachable JWKS, got success (status=%d)", statusCode)
+	}
+
+	t.Logf("FAIL-CLOSED as expected: status=%d err=%v", statusCode, verr)
+}

--- a/auth/middleware/m2m.go
+++ b/auth/middleware/m2m.go
@@ -47,6 +47,11 @@ type m2mIdentityContextKey struct{}
 // any service can reuse this by supplying its own issuer certificate.
 type M2MAuthenticator struct {
 	publicKey *rsa.PublicKey
+	// source, when non-nil, supplies the verification keys dynamically (JWKS-backed
+	// cache with serve-stale + forced refresh on signature failure). When nil the
+	// authenticator uses the legacy static single-PEM publicKey path unchanged, so
+	// the original constructor and behavior are fully preserved.
+	source KeySource
 	// expectedIssuer, when non-empty, pins the accepted token "iss" claim so a
 	// token minted by a different issuer sharing the same signing key is
 	// rejected. Empty means the issuer is not checked (acceptable only in a
@@ -72,20 +77,7 @@ type M2MAuthenticator struct {
 // signing key). Pass "" to skip the issuer check; this is only safe in a
 // single-issuer deployment and setting it is recommended otherwise.
 func NewM2MAuthenticator(certificatePEM, expectedIssuer string, enabled bool, logger *log.Logger) (*M2MAuthenticator, error) {
-	var l log.Logger
-
-	if logger != nil {
-		l = *logger
-	} else {
-		var err error
-
-		l, err = initializeDefaultLogger()
-		if err != nil {
-			stdlog.Printf("failed to initialize logger, using NopLogger: %v", err)
-
-			l = log.NewNop()
-		}
-	}
+	l := resolveM2MLogger(logger)
 
 	if !enabled {
 		return &M2MAuthenticator{publicKey: nil, expectedIssuer: expectedIssuer, enabled: false, logger: l}, nil
@@ -97,6 +89,53 @@ func NewM2MAuthenticator(certificatePEM, expectedIssuer string, enabled bool, lo
 	}
 
 	return &M2MAuthenticator{publicKey: publicKey, expectedIssuer: expectedIssuer, enabled: true, logger: l}, nil
+}
+
+// NewM2MAuthenticatorWithKeySource builds an M2MAuthenticator that resolves its
+// verification keys from a KeySource instead of a build-time PEM. This is the
+// dynamic-JWKS path: keys are served from an in-memory cache (never blocking a
+// verify on the network), and on a signature verification failure the gate forces
+// ONE single-flight refresh and retries — covering the stable-kid Casdoor rotation
+// case where refresh-on-unknown-kid never fires.
+//
+// It is strictly additive: the existing NewM2MAuthenticator and its static
+// single-PEM behavior are unchanged. When enabled is false the authenticator is a
+// pass-through and source may be nil. When enabled is true a non-nil source is
+// required, so a misconfigured service fails to start rather than silently
+// accepting unverified tokens.
+//
+// expectedIssuer pins the token "iss" claim when non-empty (defense in depth), the
+// same as the static constructor.
+func NewM2MAuthenticatorWithKeySource(source KeySource, expectedIssuer string, enabled bool, logger *log.Logger) (*M2MAuthenticator, error) {
+	l := resolveM2MLogger(logger)
+
+	if !enabled {
+		return &M2MAuthenticator{source: source, expectedIssuer: expectedIssuer, enabled: false, logger: l}, nil
+	}
+
+	if source == nil {
+		return nil, errors.New("m2m authenticator requires a non-nil key source when enabled")
+	}
+
+	return &M2MAuthenticator{source: source, expectedIssuer: expectedIssuer, enabled: true, logger: l}, nil
+}
+
+// resolveM2MLogger returns the caller's logger, or a default (falling back to a
+// NopLogger if the default cannot be built) so the authenticator never holds a nil
+// logger. Shared by both constructors.
+func resolveM2MLogger(logger *log.Logger) log.Logger {
+	if logger != nil {
+		return *logger
+	}
+
+	l, err := initializeDefaultLogger()
+	if err != nil {
+		stdlog.Printf("failed to initialize logger, using NopLogger: %v", err)
+
+		return log.NewNop()
+	}
+
+	return l
 }
 
 // RequireM2M is a Fiber middleware that rejects any request not carrying a
@@ -161,26 +200,8 @@ func (m *M2MAuthenticator) RequireM2M() fiber.Handler {
 // checks, then requires the whitelisted "application" token type. It never logs
 // the token itself.
 func (m *M2MAuthenticator) verify(ctx context.Context, span trace.Span, accessToken string) (jwt.MapClaims, int, error) {
-	if m.publicKey == nil {
-		err := errors.New("m2m authenticator has no verification key")
-
-		logErrorf(ctx, m.logger, "M2M authentication misconfigured: missing verification key")
-		tracing.HandleSpanError(span, "M2M authentication misconfigured", err)
-
-		return nil, http.StatusUnauthorized, err
-	}
-
-	// verifyToken is the shared hardened RS256 verifier: it pins RS256 (closing the
-	// alg-substitution hole — a token forged with "none" or with HS256 using the
-	// public key as the shared secret is rejected before the keyfunc runs), requires
-	// "exp" (Casdoor always emits it, so a non-expiring credential cannot slip
-	// through), and pins "iss" when expectedIssuer is set. A single-key set is passed
-	// here; the general path may pass several for rotation overlap.
-	claims, statusCode, err := verifyToken([]*rsa.PublicKey{m.publicKey}, m.expectedIssuer, accessToken)
+	claims, statusCode, err := m.verifySignature(ctx, span, accessToken)
 	if err != nil {
-		logErrorf(ctx, m.logger, "Failed to verify M2M token: %v", err)
-		tracing.HandleSpanError(span, "Failed to verify M2M token", err)
-
 		return nil, statusCode, err
 	}
 
@@ -205,6 +226,162 @@ func (m *M2MAuthenticator) verify(ctx context.Context, span trace.Span, accessTo
 	}
 
 	return claims, http.StatusOK, nil
+}
+
+// verifySignature cryptographically verifies the token through the shared hardened
+// verifyToken (RS256 + exp + iss pins), resolving the verification keys from the
+// static publicKey (legacy path) or the dynamic KeySource. On the source path a
+// signature/keys failure triggers exactly ONE forced single-flight refresh and one
+// retry — the stable-kid Casdoor rotation case — while exp/iss/alg/malformed
+// failures never refresh (they are not key staleness). It never logs the token.
+func (m *M2MAuthenticator) verifySignature(ctx context.Context, span trace.Span, accessToken string) (jwt.MapClaims, int, error) {
+	// Legacy static single-PEM path — unchanged behavior when no KeySource is set.
+	if m.source == nil {
+		if m.publicKey == nil {
+			err := errors.New("m2m authenticator has no verification key")
+
+			logErrorf(ctx, m.logger, "M2M authentication misconfigured: missing verification key")
+			tracing.HandleSpanError(span, "M2M authentication misconfigured", err)
+
+			return nil, http.StatusUnauthorized, err
+		}
+
+		// verifyToken pins RS256 (closing the alg-substitution hole — a token forged
+		// with "none" or HS256 using the public key as the shared secret is rejected
+		// before the keyfunc runs), requires "exp", and pins "iss" when set.
+		claims, statusCode, err := verifyToken([]*rsa.PublicKey{m.publicKey}, m.expectedIssuer, accessToken)
+		if err != nil {
+			logErrorf(ctx, m.logger, "Failed to verify M2M token: %v", err)
+			tracing.HandleSpanError(span, "Failed to verify M2M token", err)
+
+			return nil, statusCode, err
+		}
+
+		return claims, statusCode, nil
+	}
+
+	// Dynamic key-source path — shared verbatim with AuthClient.extractClaims so the
+	// stable-kid rotation recovery (and its instrumentation) lives in exactly ONE
+	// place. Resolves keys from the cache (never blocks on the network), verifies, and
+	// retries once behind a forced refresh on key staleness.
+	return verifyTokenWithSource(ctx, span, m.source, m.expectedIssuer, accessToken, m.logger)
+}
+
+// verifyTokenWithSource is the shared dynamic-JWKS verification path used by BOTH the
+// M2M gate (M2MAuthenticator.verifySignature) and AuthClient.extractClaims. There is
+// exactly ONE cryptographic verifier — the shared hardened verifyToken (RS256 + exp +
+// iss pins); this helper only wraps it with the KeySource resolve + forced
+// refresh-and-retry on genuine key staleness. On a retriable signature failure it
+// forces ONE single-flight refresh and retries exactly once (THE stable-kid Casdoor
+// gotcha, where refresh-on-unknown-kid never fires); exp/iss/alg/malformed failures
+// never refresh (they are not key staleness). It emits jwks_unknown_kid_total (a
+// metric-only kid-presence probe) and jwks_verify_fail_total (on a genuine verify
+// failure), and never logs the token.
+func verifyTokenWithSource(ctx context.Context, span trace.Span, source KeySource, expectedIssuer, accessToken string, logger log.Logger) (jwt.MapClaims, int, error) {
+	keys := source.Keys(ctx)
+
+	// Metric-only: flag a token whose kid is absent from the cached JWKS. This does
+	// NOT influence verification (which still tries all keys); it is the signal that
+	// later distinguishes a new-kid rotation from the stable-kid case.
+	recordUnknownKID(ctx, source, accessToken)
+
+	claims, statusCode, err := verifyToken(keys, expectedIssuer, accessToken)
+	if err != nil && isRetriableKeyFailure(keys, err, accessToken) {
+		// THE gotcha: Casdoor republishes a regenerated keypair under the SAME kid
+		// (cert-built-in), so refresh-on-unknown-kid never fires. Force ONE
+		// single-flight refresh and retry exactly once.
+		if rerr := source.Refresh(ctx); rerr != nil {
+			logErrorf(ctx, logger, "Forced JWKS refresh failed after signature failure: %v", rerr)
+			tracing.HandleSpanError(span, "Forced JWKS refresh failed", rerr)
+			incrJWKSCounter(ctx, metricJWKSVerifyFailTotal, nil)
+
+			// Fail closed on the original verification error.
+			return nil, statusCode, err
+		}
+
+		keys = source.Keys(ctx)
+		claims, statusCode, err = verifyToken(keys, expectedIssuer, accessToken)
+	}
+
+	if err != nil {
+		logErrorf(ctx, logger, "Failed to verify token: %v", err)
+		tracing.HandleSpanError(span, "Failed to verify token", err)
+		incrJWKSCounter(ctx, metricJWKSVerifyFailTotal, nil)
+
+		return nil, statusCode, err
+	}
+
+	return claims, statusCode, nil
+}
+
+// recordUnknownKID emits jwks_unknown_kid_total when the token presents a kid absent
+// from the source's cached JWKS. It is METRIC-ONLY and never affects verification.
+// Sources that do not track kids (static/PEM) are skipped, as are tokens carrying no
+// kid (an absent kid is not the new-kid-rotation signal this metric surfaces). The
+// kid is read from the UNVERIFIED header — safe because it drives a counter only,
+// never a trust decision.
+func recordUnknownKID(ctx context.Context, source KeySource, accessToken string) {
+	checker, ok := source.(kidPresenceChecker)
+	if !ok {
+		return
+	}
+
+	kid := unverifiedKID(accessToken)
+	if kid == "" {
+		return
+	}
+
+	if !checker.hasKID(kid) {
+		incrJWKSCounter(ctx, metricJWKSUnknownKIDTotal, nil)
+	}
+}
+
+// unverifiedKID returns the "kid" JWT header parameter WITHOUT verifying the token.
+// Used solely to feed jwks_unknown_kid_total; it never influences verification.
+func unverifiedKID(accessToken string) string {
+	token, _, err := jwt.NewParser().ParseUnverified(accessToken, jwt.MapClaims{})
+	if err != nil {
+		return ""
+	}
+
+	kid, _ := token.Header["kid"].(string)
+
+	return kid
+}
+
+// isRetriableKeyFailure reports whether a verifyToken failure indicates possible
+// key staleness — the only condition that warrants a forced JWKS refresh + retry.
+//
+// It is deliberately narrow to keep verification fail-closed and avoid a refresh
+// loop on attack/claim failures:
+//   - an empty key set (cache not yet warmed) is retriable — a fetch may populate it;
+//   - otherwise ONLY a genuine RS256 signature mismatch is retriable. jwt/v5 reports
+//     alg-confusion (HS256 or "none", rejected by WithValidMethods) as
+//     ErrTokenSignatureInvalid TOO, so the token's header alg is checked and must be
+//     exactly RS256; an alg-confusion attempt never triggers a refresh;
+//   - exp/iss/malformed use other sentinels (ErrTokenExpired/ErrTokenInvalidIssuer/
+//     ErrTokenMalformed) and are never retriable.
+func isRetriableKeyFailure(keys []*rsa.PublicKey, err error, accessToken string) bool {
+	if err == nil {
+		return false
+	}
+
+	if len(keys) == 0 {
+		return true
+	}
+
+	if !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+		return false
+	}
+
+	token, _, perr := jwt.NewParser().ParseUnverified(accessToken, jwt.MapClaims{})
+	if perr != nil {
+		return false
+	}
+
+	alg, _ := token.Header["alg"].(string)
+
+	return alg == "RS256"
 }
 
 // M2MIdentityFromContext returns the authenticated M2M identity that RequireM2M

--- a/auth/middleware/metrics.go
+++ b/auth/middleware/metrics.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	observability "github.com/LerianStudio/lib-observability/v2"
+	"github.com/LerianStudio/lib-observability/v2/log"
+	"github.com/LerianStudio/lib-observability/v2/metrics"
+)
+
+// JWKS key-source metric definitions (card 1.1.8). Names/units follow the
+// lib-observability/v2 metrics.Metric convention (mirroring metrics.MetricAccountsCreated
+// et al.): a unit of "1" for dimensionless counters and "s" for the age gauge.
+var (
+	// metricJWKSRefreshTotal counts upstream JWKS fetch outcomes, labelled result=ok|fail.
+	metricJWKSRefreshTotal = metrics.Metric{
+		Name:        "jwks_refresh_total",
+		Unit:        "1",
+		Description: "Number of upstream JWKS fetch outcomes by result (ok|fail).",
+	}
+
+	// metricJWKSCacheAgeSeconds gauges the age of the currently-served JWKS keys.
+	metricJWKSCacheAgeSeconds = metrics.Metric{
+		Name:        "jwks_cache_age_seconds",
+		Unit:        "s",
+		Description: "Age in seconds of the currently-served JWKS keys (since the last successful live fetch).",
+	}
+
+	// metricJWKSVerifyFailTotal counts token verification failures on the dynamic
+	// JWKS key-source path (a real signature/key-staleness or claim-shape verify
+	// failure — NOT token-type/sub, which are enforced downstream of verifySignature).
+	metricJWKSVerifyFailTotal = metrics.Metric{
+		Name:        "jwks_verify_fail_total",
+		Unit:        "1",
+		Description: "Number of token verification failures on the dynamic JWKS key-source path.",
+	}
+
+	// metricJWKSUnknownKIDTotal counts tokens presenting a kid absent from the current
+	// cached JWKS key set (the future signal for a new-kid rotation). It is metric-only
+	// and never influences the verification decision.
+	metricJWKSUnknownKIDTotal = metrics.Metric{
+		Name:        "jwks_unknown_kid_total",
+		Unit:        "1",
+		Description: "Number of tokens presenting a kid absent from the current cached JWKS key set.",
+	}
+)
+
+// incrJWKSCounter increments a JWKS key-source counter by one. It is best-effort
+// and non-blocking: the metrics factory is resolved from ctx via the module's
+// NewTrackingFromContext convention (never nil — it falls back to a no-op factory
+// backed by the global meter provider), so no meter injection or constructor change
+// is needed. A failure to create/record the instrument is logged at WARN and never
+// affects the verification decision.
+func incrJWKSCounter(ctx context.Context, m metrics.Metric, labels map[string]string) {
+	logger, _, _, factory := observability.NewTrackingFromContext(ctx)
+
+	counter, err := factory.Counter(m)
+	if err != nil {
+		logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to create metric %q: %v", m.Name, err))
+
+		return
+	}
+
+	if len(labels) > 0 {
+		counter = counter.WithLabels(labels)
+	}
+
+	if err := counter.AddOne(ctx); err != nil {
+		logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to record metric %q: %v", m.Name, err))
+	}
+}
+
+// setJWKSGauge records the current value of a JWKS key-source gauge. Best-effort and
+// non-blocking, using the same factory-from-ctx convention as incrJWKSCounter.
+func setJWKSGauge(ctx context.Context, m metrics.Metric, value int64) {
+	logger, _, _, factory := observability.NewTrackingFromContext(ctx)
+
+	gauge, err := factory.Gauge(m)
+	if err != nil {
+		logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to create metric %q: %v", m.Name, err))
+
+		return
+	}
+
+	if err := gauge.Set(ctx, value); err != nil {
+		logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to record metric %q: %v", m.Name, err))
+	}
+}

--- a/auth/middleware/metrics.go
+++ b/auth/middleware/metrics.go
@@ -70,20 +70,3 @@ func incrJWKSCounter(ctx context.Context, m metrics.Metric, labels map[string]st
 		logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to record metric %q: %v", m.Name, err))
 	}
 }
-
-// setJWKSGauge records the current value of a JWKS key-source gauge. Best-effort and
-// non-blocking, using the same factory-from-ctx convention as incrJWKSCounter.
-func setJWKSGauge(ctx context.Context, m metrics.Metric, value int64) {
-	logger, _, _, factory := observability.NewTrackingFromContext(ctx)
-
-	gauge, err := factory.Gauge(m)
-	if err != nil {
-		logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to create metric %q: %v", m.Name, err))
-
-		return
-	}
-
-	if err := gauge.Set(ctx, value); err != nil {
-		logger.Log(ctx, log.LevelWarn, fmt.Sprintf("failed to record metric %q: %v", m.Name, err))
-	}
-}

--- a/auth/middleware/metrics_test.go
+++ b/auth/middleware/metrics_test.go
@@ -1,0 +1,365 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	observability "github.com/LerianStudio/lib-observability/v2"
+	"github.com/LerianStudio/lib-observability/v2/log"
+	obsmetrics "github.com/LerianStudio/lib-observability/v2/metrics"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// ---------------------------------------------------------------------------
+// Metrics test harness: a real OTEL SDK MeterProvider with a ManualReader, wired
+// into ctx exactly the way lib-observability's NewTrackingFromContext expects. This
+// asserts the four card-1.1.8 metrics end-to-end through the production emit path
+// (metrics.go), not just the underlying atomics.
+// ---------------------------------------------------------------------------
+
+func metricsCtx(t *testing.T) (context.Context, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	factory, err := obsmetrics.NewMetricsFactory(mp.Meter("lib-auth-test"), log.NewNop())
+	require.NoError(t, err)
+
+	return observability.ContextWithMetricFactory(context.Background(), factory), reader
+}
+
+// counterValue sums the int64 counter `name`, optionally filtered to the data point
+// carrying attribute attrKey=attrVal (pass "" for both to sum all points).
+func counterValue(t *testing.T, reader *sdkmetric.ManualReader, name, attrKey, attrVal string) int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var total int64
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %q is not an int64 Sum", name)
+
+			for _, dp := range sum.DataPoints {
+				if attrKey == "" {
+					total += dp.Value
+
+					continue
+				}
+
+				if v, present := dp.Attributes.Value(attribute.Key(attrKey)); present && v.AsString() == attrVal {
+					total += dp.Value
+				}
+			}
+		}
+	}
+
+	return total
+}
+
+// gaugeValue returns the last recorded value of the int64 gauge `name`.
+func gaugeValue(t *testing.T, reader *sdkmetric.ManualReader, name string) (int64, bool) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+
+			g, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok, "metric %q is not an int64 Gauge", name)
+
+			if len(g.DataPoints) == 0 {
+				return 0, false
+			}
+
+			return g.DataPoints[len(g.DataPoints)-1].Value, true
+		}
+	}
+
+	return 0, false
+}
+
+// ---------------------------------------------------------------------------
+// jwks_refresh_total{result=ok|fail}
+// ---------------------------------------------------------------------------
+
+func TestMetrics_JWKSRefreshTotal_OK(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	ctx, reader := metricsCtx(t)
+
+	require.NoError(t, source.Refresh(ctx))
+
+	assert.Equal(t, int64(1), counterValue(t, reader, "jwks_refresh_total", "result", "ok"),
+		"a successful upstream fetch increments jwks_refresh_total{result=ok}")
+	assert.Equal(t, int64(0), counterValue(t, reader, "jwks_refresh_total", "result", "fail"))
+	assert.Equal(t, int64(1), source.refreshOK.Load(), "the retained atomic tracks the same outcome")
+}
+
+func TestMetrics_JWKSRefreshTotal_Fail(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	ctx, reader := metricsCtx(t)
+
+	require.Error(t, source.Refresh(ctx))
+
+	assert.Equal(t, int64(1), counterValue(t, reader, "jwks_refresh_total", "result", "fail"),
+		"a failed upstream fetch increments jwks_refresh_total{result=fail}")
+	assert.Equal(t, int64(0), counterValue(t, reader, "jwks_refresh_total", "result", "ok"))
+	assert.Equal(t, int64(1), source.refreshFail.Load(), "the retained atomic tracks the same outcome")
+}
+
+// ---------------------------------------------------------------------------
+// jwks_cache_age_seconds
+// ---------------------------------------------------------------------------
+
+func TestMetrics_JWKSCacheAgeSeconds_DerivedFromFetchedAt(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	clock := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	source.now = clock.Now
+
+	ctx, reader := metricsCtx(t)
+
+	// Live fetch stamps fetchedAt at t0.
+	require.NoError(t, source.Refresh(ctx))
+
+	// 42s later, serving the keys reports their age.
+	clock.Advance(42 * time.Second)
+
+	_ = source.Keys(ctx)
+
+	age, ok := gaugeValue(t, reader, "jwks_cache_age_seconds")
+	require.True(t, ok, "serving keys after a live fetch must record jwks_cache_age_seconds")
+	assert.Equal(t, int64(42), age, "cache age is now() - fetchedAt in seconds")
+}
+
+func TestMetrics_JWKSCacheAgeSeconds_BootstrapOnly_NotEmitted(t *testing.T) {
+	t.Parallel()
+
+	priv, _ := pubKeyOf(t)
+
+	source, err := newJWKSKeySource(JWKSConfig{
+		URL:          "http://127.0.0.1:0/jwks",
+		BootstrapPEM: []byte(pubPEMOf(t, priv)),
+	})
+	require.NoError(t, err)
+
+	ctx, reader := metricsCtx(t)
+
+	// Only a bootstrap seed (no live fetch): fetchedAt is zero, so no age is reported
+	// (a seed-only source must never emit a spurious multi-decade age).
+	_ = source.Keys(ctx)
+
+	_, ok := gaugeValue(t, reader, "jwks_cache_age_seconds")
+	assert.False(t, ok, "a bootstrap-only source must not emit jwks_cache_age_seconds")
+}
+
+// ---------------------------------------------------------------------------
+// jwks_verify_fail_total
+// ---------------------------------------------------------------------------
+
+func TestMetrics_JWKSVerifyFailTotal_OnSignatureFailure(t *testing.T) {
+	t.Parallel()
+
+	attackerPriv, _ := pubKeyOf(t)
+	_, serverPub := pubKeyOf(t)
+
+	source := &fakeKeySource{keys: []*rsa.PublicKey{serverPub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	token := signRS256(t, attackerPriv, applicationClaims())
+
+	ctx, reader := metricsCtx(t)
+
+	_, statusCode, err := m.verify(ctx, noopSpan(), token)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+
+	assert.Equal(t, int64(1), counterValue(t, reader, "jwks_verify_fail_total", "", ""),
+		"a source-path signature verification failure increments jwks_verify_fail_total")
+}
+
+func TestMetrics_JWKSVerifyFailTotal_NotEmittedOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+	m := newSourceAuthenticator(t, source, "")
+
+	token := signRS256(t, priv, applicationClaims())
+
+	ctx, reader := metricsCtx(t)
+
+	_, statusCode, err := m.verify(ctx, noopSpan(), token)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	assert.Equal(t, int64(0), counterValue(t, reader, "jwks_verify_fail_total", "", ""),
+		"a token that verifies must not increment jwks_verify_fail_total")
+}
+
+// ---------------------------------------------------------------------------
+// jwks_unknown_kid_total (metric-only kid-presence probe; verification unaffected)
+// ---------------------------------------------------------------------------
+
+func TestMetrics_JWKSUnknownKIDTotal_OnUnknownKID(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+	require.NoError(t, source.Refresh(context.Background()))
+
+	m := newSourceAuthenticator(t, source, "")
+
+	// A VALID token (signed by the cached key) whose header carries a kid absent from
+	// the JWKS. Verification still succeeds (keys are tried without kid lookup); the
+	// unknown-kid metric fires purely as a signal.
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, applicationClaims())
+	tok.Header["kid"] = "totally-unknown-kid"
+
+	signed, err := tok.SignedString(priv)
+	require.NoError(t, err)
+
+	ctx, reader := metricsCtx(t)
+
+	_, statusCode, verr := m.verify(ctx, noopSpan(), signed)
+	require.NoError(t, verr, "verification must be unaffected by the kid-presence probe")
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	assert.Equal(t, int64(1), counterValue(t, reader, "jwks_unknown_kid_total", "", ""),
+		"a token whose kid is absent from the cached JWKS increments jwks_unknown_kid_total")
+	assert.Equal(t, int64(0), counterValue(t, reader, "jwks_verify_fail_total", "", ""),
+		"the token still verified, so verify_fail must not move")
+}
+
+func TestMetrics_JWKSUnknownKIDTotal_KnownKID_NotEmitted(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+	require.NoError(t, source.Refresh(context.Background()))
+
+	m := newSourceAuthenticator(t, source, "")
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, applicationClaims())
+	tok.Header["kid"] = "cert-built-in" // the kid the JWKS published
+
+	signed, err := tok.SignedString(priv)
+	require.NoError(t, err)
+
+	ctx, reader := metricsCtx(t)
+
+	_, _, verr := m.verify(ctx, noopSpan(), signed)
+	require.NoError(t, verr)
+
+	assert.Equal(t, int64(0), counterValue(t, reader, "jwks_unknown_kid_total", "", ""),
+		"a token whose kid IS in the cached JWKS must not increment jwks_unknown_kid_total")
+}
+
+// ---------------------------------------------------------------------------
+// hasKID: the observable state feeding jwks_unknown_kid_total
+// ---------------------------------------------------------------------------
+
+func TestJWKSKeySource_HasKID_TracksFetchedKIDs(t *testing.T) {
+	t.Parallel()
+
+	_, pub := pubKeyOf(t)
+	body := jwksJSON(t, "cert-built-in", pub)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	source, err := newJWKSKeySource(JWKSConfig{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+
+	// Before any fetch, no kid is known.
+	assert.False(t, source.hasKID("cert-built-in"))
+
+	require.NoError(t, source.Refresh(context.Background()))
+
+	assert.True(t, source.hasKID("cert-built-in"), "a fetched kid is tracked")
+	assert.False(t, source.hasKID("some-other-kid"), "an unfetched kid is not tracked")
+}
+
+func TestUnverifiedKID_MalformedToken_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	// A token that cannot be parsed yields no kid (the metric probe stays silent),
+	// and never influences verification.
+	assert.Equal(t, "", unverifiedKID("not-a-jwt"))
+	assert.Equal(t, "", unverifiedKID(""))
+}

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -101,6 +101,15 @@ type AuthClient struct {
 	// verifyIssuer, when non-empty, pins the accepted token "iss" claim during local
 	// verification. Read once from AUTH_JWT_ISSUER; inert when verifyKeys is empty.
 	verifyIssuer string
+
+	// source, when non-nil, supplies verification keys dynamically from a JWKS-backed
+	// KeySource — the SAME dynamic path the M2M gate uses (serve-stale cache + forced
+	// refresh-and-retry on a signature failure, the stable-kid rotation case). It is
+	// opt-in and additive: set via WithKeySource after NewAuthClient. When nil (the
+	// default) extractClaims preserves the exact env-PEM / ParseUnverified behavior.
+	// When set it takes precedence over verifyKeys for the verified path, and both
+	// route their crypto through the single shared verifyToken.
+	source KeySource
 }
 
 type AuthResponse struct {
@@ -215,6 +224,23 @@ func initializeDefaultLogger() (log.Logger, error) {
 	}
 
 	return logger, nil
+}
+
+// WithKeySource wires a dynamic JWKS KeySource into the client's local token
+// verification, mirroring the M2M gate's dynamic path (serve-stale cache + forced
+// refresh-and-retry on a signature failure). It is additive and opt-in: the default
+// client (no KeySource) verifies via the env-configured PEM keys or, absent those,
+// preserves the historical ParseUnverified behavior. When set, the KeySource takes
+// precedence over the env-PEM keys for the verified path. Returns the receiver for
+// fluent configuration after NewAuthClient; a nil receiver or nil source is a no-op.
+func (auth *AuthClient) WithKeySource(source KeySource) *AuthClient {
+	if auth == nil || source == nil {
+		return auth
+	}
+
+	auth.source = source
+
+	return auth
 }
 
 // NewAuthClient creates a new instance of AuthClient.

--- a/auth/middleware/verification.go
+++ b/auth/middleware/verification.go
@@ -69,14 +69,26 @@ func verifyToken(pubKeys []*rsa.PublicKey, expectedIssuer, accessToken string) (
 
 // extractClaims returns the token claims used to build the authorization subject.
 //
-// When local verification is configured (verifyKeys present, from
-// AUTH_JWT_VERIFY_CERT / AUTH_JWT_VERIFY_CERT_PATH) it cryptographically verifies
-// the token first (signature/alg/exp/iss) and fails closed on any error before the
-// claims are used. When it is NOT configured it preserves the historical
-// ParseUnverified behavior exactly — the network authorization call remains the
-// trust anchor — so the feature is opt-in and backward compatible. Verification is
-// gated by presence of a cert, mirroring the M2M cert gate.
+// It routes ALL cryptographic decisions through the single authoritative verifyToken
+// (RS256 + exp + iss), exactly as the M2M gate does — there is one verifier, not two.
+//
+// Three sources of verification keys, in precedence order, all opt-in and additive:
+//  1. a dynamic JWKS KeySource wired via WithKeySource (the same path the M2M gate
+//     uses): resolves keys from the serve-stale cache and forces ONE refresh-and-retry
+//     on a signature failure (the stable-kid rotation case), via the shared
+//     verifyTokenWithSource helper;
+//  2. static env-PEM keys (verifyKeys, from AUTH_JWT_VERIFY_CERT /
+//     AUTH_JWT_VERIFY_CERT_PATH): cryptographically verifies and fails closed;
+//  3. neither configured: preserves the historical ParseUnverified behavior EXACTLY
+//     — the network authorization call remains the trust anchor.
+//
+// Default construction sets neither a KeySource nor verifyKeys, so the unverified
+// path (3) is unchanged and the feature is fully backward compatible.
 func (auth *AuthClient) extractClaims(ctx context.Context, span trace.Span, accessToken string) (jwt.MapClaims, int, error) {
+	if auth.source != nil {
+		return verifyTokenWithSource(ctx, span, auth.source, auth.verifyIssuer, accessToken, auth.Logger)
+	}
+
 	if len(auth.verifyKeys) > 0 {
 		claims, statusCode, err := verifyToken(auth.verifyKeys, auth.verifyIssuer, accessToken)
 		if err != nil {

--- a/auth/middleware/verification_test.go
+++ b/auth/middleware/verification_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -488,4 +489,83 @@ func TestNewAuthClient_VerificationConfig(t *testing.T) {
 		client := NewAuthClient("", false, &logger)
 		assert.Len(t, client.verifyKeys, 1)
 	})
+}
+
+// ---------------------------------------------------------------------------
+// extractClaims via a dynamic KeySource (card 1.1.7 convergence, lib-auth side)
+//
+// These prove AuthClient's verified path shares the SAME verifyToken + KeySource
+// refresh-and-retry machinery as the M2M gate, and that WithKeySource is additive:
+// the default (nil source) path is untouched.
+// ---------------------------------------------------------------------------
+
+func TestExtractClaims_KeySource_ValidToken_Verifies(t *testing.T) {
+	t.Parallel()
+
+	key, _ := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{&key.PublicKey}}
+
+	auth := (&AuthClient{Enabled: true, Logger: &testLogger{}}).WithKeySource(source)
+
+	token := signRS256(t, key, normalUserClaims())
+
+	claims, statusCode, err := auth.extractClaims(context.Background(), noopSpan(), token)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "user-123", claims["sub"])
+	assert.Equal(t, 0, source.refreshes(), "a token that verifies on the first try must not refresh")
+}
+
+// The stable-kid rotation recovery is shared: a token signed by a rotated key that is
+// not yet cached triggers exactly ONE forced refresh, then verifies — identical to
+// the M2M gate, via the same verifyTokenWithSource helper.
+func TestExtractClaims_KeySource_StaleKey_RefreshesOnceAndRetries(t *testing.T) {
+	t.Parallel()
+
+	_, oldPub := pubKeyOf(t)
+	newPriv, newPub := pubKeyOf(t)
+
+	source := &fakeKeySource{
+		keys:      []*rsa.PublicKey{oldPub},
+		onRefresh: func() []*rsa.PublicKey { return []*rsa.PublicKey{newPub} },
+	}
+
+	auth := (&AuthClient{Enabled: true, Logger: &testLogger{}}).WithKeySource(source)
+
+	token := signRS256(t, newPriv, normalUserClaims())
+
+	claims, statusCode, err := auth.extractClaims(context.Background(), noopSpan(), token)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "user-123", claims["sub"])
+	assert.Equal(t, 1, source.refreshes(), "exactly ONE forced refresh on the signature failure")
+}
+
+func TestExtractClaims_KeySource_ForgedToken_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	attackerKey, _ := pubKeyOf(t)
+	_, serverPub := pubKeyOf(t)
+
+	source := &fakeKeySource{keys: []*rsa.PublicKey{serverPub}}
+
+	auth := (&AuthClient{Enabled: true, Logger: &testLogger{}}).WithKeySource(source)
+
+	token := signRS256(t, attackerKey, normalUserClaims())
+
+	_, statusCode, err := auth.extractClaims(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+}
+
+// WithKeySource is strictly additive: a client with no KeySource keeps the exact
+// prior behavior (env-PEM verifyKeys, else ParseUnverified).
+func TestWithKeySource_NilSource_NoOp(t *testing.T) {
+	t.Parallel()
+
+	auth := (&AuthClient{Enabled: true, Logger: &testLogger{}}).WithKeySource(nil)
+	assert.Nil(t, auth.source)
 }

--- a/auth/middleware/verification_test.go
+++ b/auth/middleware/verification_test.go
@@ -559,6 +559,31 @@ func TestExtractClaims_KeySource_ForgedToken_FailsClosed(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.LessOrEqual(t, source.refreshes(), 1,
+		"a forged (bad-signature) token forces at most ONE refresh, never a loop")
+}
+
+// An expired but validly-signed token is a CLAIM failure, not key staleness: the
+// source-path retry logic must NOT force any refresh.
+func TestExtractClaims_KeySource_ExpiredToken_NoRefresh(t *testing.T) {
+	t.Parallel()
+
+	key, pub := pubKeyOf(t)
+	source := &fakeKeySource{keys: []*rsa.PublicKey{pub}}
+
+	auth := (&AuthClient{Enabled: true, Logger: &testLogger{}}).WithKeySource(source)
+
+	claims := normalUserClaims()
+	claims["exp"] = float64(time.Now().Add(-time.Hour).Unix())
+
+	token := signRS256(t, key, claims)
+
+	_, statusCode, err := auth.extractClaims(context.Background(), noopSpan(), token)
+
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, statusCode)
+	assert.Equal(t, 0, source.refreshes(),
+		"an expired validly-signed token is a claim failure, not key staleness: ZERO refreshes")
 }
 
 // WithKeySource is strictly additive: a client with no KeySource keeps the exact

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/LerianStudio/lib-auth/v3
 go 1.26.3
 
 require (
+	github.com/MicahParks/jwkset v0.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
@@ -16,6 +17,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
+	golang.org/x/time v0.15.0 // indirect
 )
 
 require (
@@ -69,7 +71,7 @@ require (
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect
@@ -77,7 +79,7 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/LerianStudio/lib-commons/v6 v6.0.0 h1:XDKyCKdb2h3l0MBwQQNBRuCsiSTjafJ
 github.com/LerianStudio/lib-commons/v6 v6.0.0/go.mod h1:bOPZG4oO2xoSE307JJyXKyhmBo7EyQ5g8DEw5fI/ZEg=
 github.com/LerianStudio/lib-observability/v2 v2.0.0 h1:B13t2TlLvu9awqMsnJ6d0RWeftUlf1ROBxLB3okSn6c=
 github.com/LerianStudio/lib-observability/v2 v2.0.0/go.mod h1:MuHQdrM8twiwewkwSO1TX6/931mI9oTM0NCIVjumPhQ=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
@@ -275,6 +277,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
 golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=


### PR DESCRIPTION
## What & why

Verify Casdoor-issued **M2M (client_credentials) tokens against a dynamically-refreshed JWKS** from the issuer, instead of a single build-time static public key.

Motivation (PAM Map card **3755**): Casdoor republishes a regenerated keypair under the **same `kid`** (`cert-built-in`), so a captured static cert stops matching after a reseed (`401 token signature is invalid`), and key rotation currently requires a rebuild + redeploy.

**Additive & backward compatible** — the existing `NewM2MAuthenticator` (static PEM) keeps its exact signature and behavior; all pre-existing tests stay green.

## New API surface
- `KeySource interface { Keys(ctx) []*rsa.PublicKey; Refresh(ctx) error; Close() error }`
- `StaticKeySource(...)` and `NewJWKSKeySource(JWKSConfig{...})`
- `NewM2MAuthenticatorWithKeySource(source, expectedIssuer, enabled, logger)`
- `AuthClient.WithKeySource(source)` (opt-in; the AuthClient verify path can use it too)

## Design highlights
- **`verifyToken` stays the single authoritative verifier** — RS256 + `exp` + `iss` pinned. `MicahParks/jwkset` is used **only** to parse JWKS-JSON into `[]*rsa.PublicKey`; alg enforcement is never delegated to the JWKS lib.
- **Refresh on signature-verification failure** (not just unknown kid) defeats the stable-kid rotation case; short background TTL refresh; **single-flight**; forced refresh is **cooldown-throttled** (default 15s) so a stream of bad-signature tokens can't amplify into unbounded upstream fetches.
- **Fail-open availability / fail-closed verification**: bootstrap-seeded in-memory cache + serve-stale means a verify never blocks on the network and a down JWKS endpoint degrades to last-good keys, while a bad sig/alg/exp/iss is always rejected. Background refresher is context-bound and stoppable via `Close()`.

## Observability
`jwks_refresh_total{result}`, `jwks_cache_age_seconds`, `jwks_verify_fail_total`, `jwks_unknown_kid_total` (kid-presence check is metric-only — verification semantics unchanged).

## Tests
149 pass under `-race`. Covers: the gotcha (old cache + new-key token, same kid → forced refresh → retry verifies), serve-stale, the full fail-closed matrix, single-flight, the cooldown bound (N sequential bad tokens → 1 fetch), plus a **live integration test** (`//go:build integration`, skips without `M2M_TOKEN`).

## Review-time judgment calls
- `auth/middleware/live_jwks_integration_test.go` defaults to a local Casdoor URL/issuer (env-overridable, inert without `M2M_TOKEN`) — happy to drop it if you'd rather keep IdP-specifics out of the shared lib.
- `DESIGN-jwks-keysource.md` is included as the design record; can be removed if the repo prefers design docs elsewhere.
- Security review (during development) flagged one High — refresh-amplification DoS — which the cooldown addresses; logic review passed.

## Downstream
The first consumer is plugin-access-manager identity (PAM PR, currently draft — depends on this landing + a tagged release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
