### PR TITLE
fix(middleware): bind decision-cache entries to the bearer token

### DIFF
--- a/auth/middleware/decisioncache.go
+++ b/auth/middleware/decisioncache.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/sha256"
 	"hash/fnv"
 	"sync"
 	"time"
@@ -20,10 +21,26 @@ const decisionCacheShards = 16
 const decisionCacheMaxPerShard = 1024
 
 // cacheKey identifies an authorization decision by the inputs that determine it —
-// the exact fields sent to the authz service. It NEVER contains the raw token: two
-// tokens for the same subject must share a decision, and a token must never become
-// a cache key (it would leak into memory keyed by a secret).
+// the exact fields sent to the authz service — PLUS the identity of the bearer token
+// those inputs were derived from. It never holds the raw token, only its digest.
 type cacheKey struct {
+	// tokenDigest binds the entry to the exact token the authz service accepted.
+	//
+	// Without it the cache substitutes for authentication. Local JWT verification is
+	// opt-in (AUTH_JWT_VERIFY_CERT / AUTH_JWT_VERIFY_CERT_PATH / WithKeySource) and
+	// OFF by default; on that path claims come from ParseUnverified, so the authz
+	// round-trip — which carries the raw token — is the only thing that ever checks
+	// the signature. Keying on the derived claims alone means a caller can warm the
+	// cache with a genuine token and then replay the same request with a forged or
+	// payload-edited one: identical sub/resource/action/product/IP, identical key,
+	// cache hit, authz service never consulted. Digesting the token makes a forged
+	// token a cache MISS, so it reaches the verifier and is denied.
+	//
+	// It is a SHA-256 digest, not the token: a bearer secret must not sit in a map
+	// key. The cost is hit rate — two tokens for the same subject no longer share an
+	// entry — which is the correct trade against an authentication bypass.
+	tokenDigest [sha256.Size]byte
+
 	sub      string
 	resource string
 	action   string
@@ -72,7 +89,8 @@ func newDecisionCache(ttl time.Duration) *decisionCache {
 // distinct field boundaries cannot collide (e.g. {"a","b"} vs {"ab",""}).
 func (c *decisionCache) shardFor(k cacheKey) *cacheShard {
 	h := fnv.New32a()
-	_, _ = h.Write([]byte(k.sub + "\x00" + k.resource + "\x00" + k.action + "\x00" + k.product + "\x00" + k.clientIP))
+	_, _ = h.Write(k.tokenDigest[:])
+	_, _ = h.Write([]byte("\x00" + k.sub + "\x00" + k.resource + "\x00" + k.action + "\x00" + k.product + "\x00" + k.clientIP))
 
 	return c.shards[h.Sum32()%decisionCacheShards]
 }

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -72,9 +73,13 @@ type AuthClient struct {
 	timeout time.Duration
 
 	// cache, when non-nil, memoizes authorization decisions for a short TTL keyed by
-	// (sub, resource, action, product, clientIp) — NEVER the access token. clientIp
-	// is part of the key because decisions are IP-dependent (tenant IP-allowlist), so
-	// a cross-IP cache hit would bypass the allowlist; do NOT drop it from the key.
+	// (sha256(accessToken), sub, resource, action, product, clientIp) — the digest of
+	// the access token, never the token itself. clientIp is part of the key because
+	// decisions are IP-dependent (tenant IP-allowlist), so a cross-IP cache hit would
+	// bypass the allowlist. The token digest is part of the key because local JWT
+	// verification is opt-in and off by default, which makes the authz round-trip the
+	// only signature check: keyed on claims alone, a forged token would be served an
+	// entry warmed by a genuine one. Do NOT drop either from the key.
 	// Enabled by AUTH_CACHE_TTL > 0 (opt-in; nil = no caching, prior behavior). It
 	// trades a bounded revocation-propagation lag (= TTL) for load shedding and outage
 	// resilience.
@@ -576,11 +581,22 @@ func (auth *AuthClient) checkAuthorization(ctx context.Context, product, resourc
 		return false, http.StatusInternalServerError, err
 	}
 
-	// Cache key = exactly the authz request inputs (never the raw token). product is
-	// the value actually forwarded ("" when not forwarded), so the key matches the
-	// decision the authz service made. clientIP is in the key because the decision is
-	// IP-dependent (tenant IP-allowlist): a cross-IP cache hit would bypass it.
-	key := cacheKey{sub: sub, resource: resource, action: action, product: requestBody["product"], clientIP: clientIP}
+	// Cache key = the authz request inputs PLUS a digest of the bearer token they were
+	// derived from (never the raw token). product is the value actually forwarded ("" when
+	// not forwarded), so the key matches the decision the authz service made. clientIP is
+	// in the key because the decision is IP-dependent (tenant IP-allowlist): a cross-IP
+	// cache hit would bypass it. The token digest is in the key because local verification
+	// is off by default, which makes the authz round-trip the only signature check: without
+	// it a forged token with the same claims would hit an entry warmed by a genuine one and
+	// never reach the verifier.
+	key := cacheKey{
+		tokenDigest: sha256.Sum256([]byte(accessToken)),
+		sub:         sub,
+		resource:    resource,
+		action:      action,
+		product:     requestBody["product"],
+		clientIP:    clientIP,
+	}
 
 	// A fresh cache hit (positive OR negative) short-circuits before the breaker, so
 	// the breaker only ever runs on a miss — its open state then denies (never

--- a/auth/middleware/resilience_test.go
+++ b/auth/middleware/resilience_test.go
@@ -238,7 +238,7 @@ func TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow(t *testing.T) {
 
 	require.NotEqual(t, genuine, forged, "the two tokens must differ on the wire")
 
-	server, _ := countingAuthServer(t, func(w http.ResponseWriter, r *http.Request, _ int64) {
+	server, hits := countingAuthServer(t, func(w http.ResponseWriter, r *http.Request, _ int64) {
 		// The authz service verifies the signature; only the genuine token passes.
 		writeAuthorized(w, r.Header.Get("Authorization") == genuine)
 	})
@@ -257,6 +257,7 @@ func TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow(t *testing.T) {
 	authorized, _, err = auth.checkAuthorization(context.Background(), "", "res", "read", forged, "")
 	require.NoError(t, err)
 	assert.False(t, authorized, "a forged token must never be served a decision cached for a genuine one")
+	assert.Equal(t, int64(2), hits.Load(), "the forged token must miss the cache and reach authz")
 }
 
 // ---------------------------------------------------------------------------

--- a/auth/middleware/resilience_test.go
+++ b/auth/middleware/resilience_test.go
@@ -25,6 +25,23 @@ func userToken() string {
 	})
 }
 
+// forgedUserToken builds a token whose claims are byte-identical to userToken's but
+// whose signature is not: the payload-edited / forged token an attacker replays.
+func forgedUserToken() string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user-1",
+	})
+
+	signed, err := token.SignedString([]byte("attacker-secret"))
+	if err != nil {
+		panic("failed to sign forged test JWT: " + err.Error())
+	}
+
+	return signed
+}
+
 // countingAuthServer returns a server that records how many /v1/authorize requests
 // it received and responds per the supplied handler.
 func countingAuthServer(t *testing.T, handler func(w http.ResponseWriter, r *http.Request, n int64)) (*httptest.Server, *atomic.Int64) {
@@ -204,6 +221,42 @@ func TestCheckAuthorization_NegativeCache_Served(t *testing.T) {
 	}
 
 	assert.Equal(t, int64(1), hits.Load(), "a cached denial is served without re-querying")
+}
+
+// TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow proves the cache does not
+// substitute for authentication. Local JWT verification is off (the default), so the
+// authz service is the ONLY party that verifies the token signature. Two tokens carry
+// identical claims but different signatures — the shape of a payload-edited or wholly
+// forged token — and the authz service authorizes only the genuine one. The forged
+// token must therefore reach the authz service and be denied, never be served an
+// allow that was cached for the genuine token.
+func TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow(t *testing.T) {
+	t.Parallel()
+
+	genuine := userToken()
+	forged := forgedUserToken()
+
+	require.NotEqual(t, genuine, forged, "the two tokens must differ on the wire")
+
+	server, _ := countingAuthServer(t, func(w http.ResponseWriter, r *http.Request, _ int64) {
+		// The authz service verifies the signature; only the genuine token passes.
+		writeAuthorized(w, r.Header.Get("Authorization") == genuine)
+	})
+
+	auth := &AuthClient{
+		Address: server.URL,
+		Enabled: true,
+		Logger:  &testLogger{},
+		cache:   newDecisionCache(time.Minute),
+	}
+
+	authorized, _, err := auth.checkAuthorization(context.Background(), "", "res", "read", genuine, "")
+	require.NoError(t, err)
+	require.True(t, authorized, "the genuine token must be authorized and warm the cache")
+
+	authorized, _, err = auth.checkAuthorization(context.Background(), "", "res", "read", forged, "")
+	require.NoError(t, err)
+	assert.False(t, authorized, "a forged token must never be served a decision cached for a genuine one")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request Checklist

## Pull Request Type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Pipeline
- [ ] Tests
- [ ] Documentation
- [ ] Helm

## Checklist

- [x] I have tested these changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added necessary comments to the code, especially in complex areas.
- [x] I have ensured that my changes adhere to the project's coding standards.
- [x] I have checked for any potential security issues.
- [x] I have ensured that all tests pass.
- [ ] I have updated the version appropriately (if applicable).
- [x] I have confirmed this code is ready for review.

## Additional Notes

Fixes #146 — an authentication bypass in the authorization decision cache.

### What was wrong

`cacheKey` held only values *derived* from the bearer token
(`sub, resource, action, product, clientIP`), and a cache hit returned at
`middleware.go:562` — before `resolveAuthz`, the function that actually sends the token
to `/v1/authorize`. Local JWT verification is opt-in and off by default, so that
round-trip is the only signature check in the request path. Those derived values come
from `ParseUnverified`, meaning the attacker supplies them.

Consequence: warm the cache with one legitimate request, then replay it with a forged
token carrying the same claims. Same key, cache hit, verifier never called, request
allowed — for the whole TTL. Cross-tenant access is one instance; the general shape is
that authentication stops happening. Both the Fiber and gRPC paths are affected, since
both go through `checkAuthorization`.

### What changed

`cacheKey` gains a `tokenDigest [sha256.Size]byte` field, set from
`sha256.Sum256([]byte(accessToken))` at the one place the key is built. A forged token
now produces a different digest, misses the cache, reaches the authz service, and is
denied. The genuine token keeps hitting.

The digest, not the token: a bearer secret must not sit in a map key. That was the sound
half of the old comment's reasoning and it is preserved. The other half — "two tokens for
the same subject must share a decision" — is a hit-rate preference, and it is what the
bypass was standing on.

### Why not bind the key to the tenant claim

It is the obvious fix and it does not work. A forged token that leaves the tenant claim
unchanged still derives the same tenant, still produces the same key, still gets the
cached allow. Every claim available for the key comes from the same unverified parse. The
defect is that the cache substitutes for verification, not that the key is too coarse.

### Why not refuse to construct the cache without a verification cert

Considered and rejected:

- `WithKeySource` wires verification material *after* `NewAuthClient` returns, so a
  construction-time check cannot see it and would wrongly refuse a valid JWKS deployment.
- `NewAuthClient` has a no-error signature and does not panic by explicit design; there is
  no boot-refusal seam that does not break every consumer's call site.
- It would force any deployment that wants the cache to provision and rotate a
  verification certificate, to keep a performance feature. This fix needs no new
  configuration at all.

### Behavioural impact

No configuration change, no API change. The only observable difference is hit rate: two
distinct tokens for the same subject no longer share an entry. For the common case — one
caller reusing one JWT for the life of the token — the hit rate is unchanged. All six
pre-existing cache tests pass untouched, because each already replays the same token
string.

### Test

`TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow` builds two tokens with
byte-identical claims and different signatures. The fake authz service authorizes only
the genuine one. Written first, and failing against the pre-fix code:

```
=== RUN   TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow
    resilience_test.go:259:
        	Error:      	Should be false
        	Messages:   	a forged token must never be served a decision cached for a genuine one
--- FAIL: TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow (0.00s)
FAIL	github.com/LerianStudio/lib-auth/v3/auth/middleware	3.663s
```

After the fix:

```
--- PASS: TestCheckAuthorization_ForgedTokenMustNotHitCachedAllow (0.00s)
ok  	github.com/LerianStudio/lib-auth/v3/auth/middleware	0.432s
```

Full suite green, `golangci-lint run ./...` reports 0 issues.

### Residual, deliberately out of scope

A token valid when cached and since expired or revoked is still served until the TTL
elapses. That is the lag the cache already documents, not a bypass. Capping an entry's
expiry at the token's `exp` claim would close it and is sound (only tokens the authz
service accepted get a positive entry, so their `exp` is authentic), but it changes
behaviour you chose deliberately, so it belongs in its own PR if you want it.

## Obs: targeted at `develop` per the template.
