### PR TITLE
fix(middleware): inherit the request context instead of extracting inbound trace headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ with it.
 **What you will observe:** auth spans stop joining a caller-supplied
 `traceparent` unless the application itself trusts it.
 
+Note: `lib-observability v2.1.2` is an **application-level** requirement, not a
+requirement of this module — lib-auth itself does not use
+`TrustInboundTraceContext` and keeps its own minimum at `v2.0.0`. Applications
+that want to opt in to honoring inbound trace context must depend on
+`lib-observability >= v2.1.2` and enable the flag themselves.
+
 ## 🚀 How to Use
 
 ### 1. Set the needed environment variables:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,30 @@ Repository: [lib-auth](https://github.com/LerianStudio/lib-auth)
 go get github.com/LerianStudio/lib-auth/v3@latest
 ```
 
+## 🔭 Inbound trace context is not extracted by the middleware
+
+`Authorize` and `RequireM2M` used to call `tracing.ExtractHTTPContext`
+themselves, parenting their spans onto a caller-supplied `traceparent` and
+replacing the context's baggage with the inbound `baggage` header. Both now
+inherit the ambient request context.
+
+Whether an inbound trace context is honored is the **application's** decision — a
+caller that can set the header can otherwise choose this service's trace ID and
+force its sampling decision, which is why lib-observability gates it behind
+`tracing.TelemetryConfig.TrustInboundTraceContext` (default false) from `v2.1.2`
+on. lib-auth cannot see that setting, so it inherits whatever parent the
+application's telemetry middleware decided on: an app that trusts the inbound
+trace already parented its server span to it and lib-auth joins for free; an app
+that does not stays local, and so does lib-auth. Baggage sent to the
+authorization service now comes from the application's context, never from the
+wire — `propagation.Baggage.Extract` replaces the whole baggage value instead of
+merging, so self-extraction silently discarded baggage the application seeded.
+The gRPC interceptor always behaved this way; the HTTP path is now consistent
+with it.
+
+**What you will observe:** auth spans stop joining a caller-supplied
+`traceparent` unless the application itself trusts it.
+
 ## 🚀 How to Use
 
 ### 1. Set the needed environment variables:

--- a/auth/middleware/baggage_tenant_test.go
+++ b/auth/middleware/baggage_tenant_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	observability "github.com/LerianStudio/lib-observability/v2"
+	"github.com/gofiber/fiber/v3"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestAuthorize_PropagatesAmbientBaggageNotCallerSuppliedHeaders pins where
+// lib-auth's outbound baggage comes from: the ambient request context the
+// application established, never the raw inbound headers.
+//
+// Two properties ride on this. The security one: a caller-supplied
+// `tenant.id` baggage member must never reach the Access Manager, because
+// AttrBagSpanProcessor would otherwise stamp a forged tenant on every span
+// before auth has run. The correctness one: a legitimate baggage member the
+// application seeded (from a validated claim, say) must survive the
+// authorization hop rather than being replaced by whatever the caller sent —
+// propagation.Baggage.Extract REPLACES the whole baggage value rather than
+// merging, so self-extracting here silently overwrote the trusted set.
+//
+// Fails while lib-auth calls tracing.ExtractHTTPContext itself: the
+// caller's `team=payments` displaces the application's `team=platform`.
+func TestAuthorize_PropagatesAmbientBaggageNotCallerSuppliedHeaders(t *testing.T) {
+	useCompositePropagator(t)
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+
+	var outboundTraceparent, outboundBaggage string
+
+	server := authorizedAccessManager(t, &outboundTraceparent, &outboundBaggage)
+	defer server.Close()
+
+	auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
+
+	// The application's trusted baggage, as its own middleware would seed it.
+	trusted, err := baggage.Parse("team=platform")
+	require.NoError(t, err)
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		ctx := observability.ContextWithTracer(c.Context(), tp.Tracer("test"))
+		c.SetContext(baggage.ContextWithBaggage(ctx, trusted))
+
+		return c.Next()
+	})
+	app.Get("/x", auth.Authorize("midaz", "resource", "get"), func(c fiber.Ctx) error {
+		return c.SendString("reached handler")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	}))
+	req.Header.Set("Baggage", "tenant.id=forged-tenant,team=payments")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.NotContains(t, outboundBaggage, "tenant.id",
+		"a caller-supplied tenant.id baggage member must never be propagated onward")
+	assert.NotContains(t, outboundBaggage, "team=payments",
+		"a caller-supplied baggage member must not displace the application's own")
+	assert.Contains(t, outboundBaggage, "team=platform",
+		"baggage the application seeded must survive the authorization hop")
+}

--- a/auth/middleware/inbound_trace_context_test.go
+++ b/auth/middleware/inbound_trace_context_test.go
@@ -93,7 +93,11 @@ func authorizedAccessManager(t *testing.T, traceparent, baggageHeader *string) *
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		require.NoError(t, json.NewEncoder(w).Encode(AuthResponse{Authorized: true}))
+		// The handler runs in a separate goroutine, so it must not call
+		// require (FailNow); report the error non-fatally instead.
+		if err := json.NewEncoder(w).Encode(AuthResponse{Authorized: true}); err != nil {
+			t.Errorf("encoding stub Access Manager response: %v", err)
+		}
 	}))
 }
 

--- a/auth/middleware/inbound_trace_context_test.go
+++ b/auth/middleware/inbound_trace_context_test.go
@@ -1,0 +1,202 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	observability "github.com/LerianStudio/lib-observability/v2"
+	"github.com/gofiber/fiber/v3"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// forgedInboundTraceID is the trace an untrusted caller tries to pin this
+// service's spans onto by setting a `traceparent` header itself.
+const forgedInboundTraceID = "1111111111111111111111111111111f"
+
+// useCompositePropagator installs the same propagator lib-observability's
+// NewTelemetry installs at bootstrap. Inbound extraction reads the GLOBAL
+// propagator (tracing.ExtractTraceContext -> otel.GetTextMapPropagator), so
+// without this a test cannot tell extraction from non-extraction: the default
+// global propagator is a no-op and every traceparent silently disappears.
+// Not parallel-safe — callers must not t.Parallel().
+func useCompositePropagator(t *testing.T) {
+	t.Helper()
+
+	prev := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
+}
+
+// appTelemetryMiddleware stands in for the application's own telemetry
+// middleware (lib-observability's TelemetryMiddleware.WithTelemetry) on the
+// posture where the inbound traceparent is NOT trusted: it starts a LOCAL root
+// server span and deliberately does not extract the inbound traceparent. It
+// reports the local trace ID through the returned pointer.
+func appTelemetryMiddleware(tp *sdktrace.TracerProvider) (fiber.Handler, *trace.TraceID) {
+	var localTraceID trace.TraceID
+
+	return func(c fiber.Ctx) error {
+		tracer := tp.Tracer("test")
+
+		ctx, span := tracer.Start(
+			observability.ContextWithTracer(c.Context(), tracer),
+			"server",
+			trace.WithSpanKind(trace.SpanKindServer),
+		)
+		defer span.End()
+
+		localTraceID = span.SpanContext().TraceID()
+
+		c.SetContext(ctx)
+
+		return c.Next()
+	}, &localTraceID
+}
+
+// findSpan returns the exported span with the given name.
+func findSpan(t *testing.T, exporter *tracetest.InMemoryExporter, name string) tracetest.SpanStub {
+	t.Helper()
+
+	for _, s := range exporter.GetSpans() {
+		if s.Name == name {
+			return s
+		}
+	}
+
+	require.FailNowf(t, "span not exported", "no span named %q among %d exported", name, len(exporter.GetSpans()))
+
+	return tracetest.SpanStub{}
+}
+
+// authorizedAccessManager is a stub Access Manager that authorizes everything
+// and records the trace context and baggage lib-auth propagates to it.
+func authorizedAccessManager(t *testing.T, traceparent, baggageHeader *string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*traceparent = r.Header.Get("Traceparent")
+		*baggageHeader = r.Header.Get("Baggage")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		require.NoError(t, json.NewEncoder(w).Encode(AuthResponse{Authorized: true}))
+	}))
+}
+
+// TestAuthorize_StaysInLocalTraceDespiteInboundTraceparent pins the trust
+// posture lib-auth must inherit rather than override.
+//
+// Honoring an inbound traceparent is the APPLICATION's decision — an untrusted
+// caller that can set the header can otherwise choose this service's trace ID
+// and force its sampling decision, which is why lib-observability gates it
+// behind tracing.TelemetryConfig.TrustInboundTraceContext (default false) from
+// v2.1.2 on. lib-auth has no view of that setting, so it must not extract
+// inbound trace context on its own: it starts its span from the ambient request
+// context and inherits whatever parent the application's telemetry middleware
+// already decided on. An app that DOES trust the inbound trace already has its
+// server span parented to it, so lib-auth joins automatically; an app that does
+// not stays local, and so does lib-auth.
+//
+// Fails while lib-auth calls tracing.ExtractHTTPContext itself: the authorize
+// span re-parents to the caller-supplied trace, detaching from the
+// application's server span.
+func TestAuthorize_StaysInLocalTraceDespiteInboundTraceparent(t *testing.T) {
+	useCompositePropagator(t)
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+
+	var outboundTraceparent, outboundBaggage string
+
+	server := authorizedAccessManager(t, &outboundTraceparent, &outboundBaggage)
+	defer server.Close()
+
+	auth := &AuthClient{Address: server.URL, Enabled: true, Logger: &testLogger{}}
+
+	telemetry, localTraceID := appTelemetryMiddleware(tp)
+
+	app := fiber.New()
+	app.Use(telemetry)
+	app.Get("/x", auth.Authorize("midaz", "resource", "get"), func(c fiber.Ctx) error {
+		return c.SendString("reached handler")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+createTestJWT(jwt.MapClaims{
+		"type":  "normal-user",
+		"owner": "acme-org",
+		"sub":   "user123",
+	}))
+	req.Header.Set("Traceparent", "00-"+forgedInboundTraceID+"-2222222222222222-01")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	authorizeSpan := findSpan(t, exporter, "lib_auth.authorize")
+	gotTraceID := authorizeSpan.SpanContext.TraceID().String()
+
+	assert.NotEqual(t, forgedInboundTraceID, gotTraceID,
+		"the authorize span must never join a trace chosen by a caller-supplied traceparent")
+	assert.Equal(t, localTraceID.String(), gotTraceID,
+		"the authorize span must nest under the application's own server span")
+
+	require.NotEmpty(t, outboundTraceparent, "trace context must still propagate to the Access Manager")
+	assert.Contains(t, outboundTraceparent, localTraceID.String(),
+		"the Access Manager call must be reported inside the local trace, not the forged one")
+}
+
+// TestRequireM2M_StaysInLocalTraceDespiteInboundTraceparent pins the same
+// posture on the M2M authentication middleware, which shared the same
+// self-extraction defect.
+func TestRequireM2M_StaysInLocalTraceDespiteInboundTraceparent(t *testing.T) {
+	useCompositePropagator(t)
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+
+	key, pubPEM := newTestRSAKeyPEM(t)
+	authenticator := newTestM2MAuthenticator(t, pubPEM)
+
+	telemetry, localTraceID := appTelemetryMiddleware(tp)
+
+	app := fiber.New()
+	app.Use(telemetry)
+	app.Get("/x", authenticator.RequireM2M(), func(c fiber.Ctx) error {
+		return c.SendString("reached handler")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Authorization", "Bearer "+signRS256(t, key, applicationClaims()))
+	req.Header.Set("Traceparent", "00-"+forgedInboundTraceID+"-2222222222222222-01")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	m2mSpan := findSpan(t, exporter, "lib_auth.require_m2m")
+	gotTraceID := m2mSpan.SpanContext.TraceID().String()
+
+	assert.NotEqual(t, forgedInboundTraceID, gotTraceID,
+		"the require_m2m span must never join a trace chosen by a caller-supplied traceparent")
+	assert.Equal(t, localTraceID.String(), gotTraceID,
+		"the require_m2m span must nest under the application's own server span")
+}

--- a/auth/middleware/m2m.go
+++ b/auth/middleware/m2m.go
@@ -156,7 +156,11 @@ func (m *M2MAuthenticator) RequireM2M() fiber.Handler {
 			return c.Next()
 		}
 
-		ctx := tracing.ExtractHTTPContext(c.Context(), c)
+		// Inherit the ambient request context rather than extracting inbound trace
+		// context here — same reasoning as AuthClient.Authorize: honoring a
+		// caller-supplied traceparent is the application's decision to make, not
+		// this middleware's.
+		ctx := c.Context()
 
 		_, tracer, reqID, _ := observability.NewTrackingFromContext(ctx)
 

--- a/auth/middleware/middleware.go
+++ b/auth/middleware/middleware.go
@@ -352,7 +352,21 @@ func (auth *AuthClient) mustRefuse() bool {
 // If the user is authorized, the request is passed to the next handler; otherwise, a 403 Forbidden status is returned.
 func (auth *AuthClient) Authorize(product, resource, action string) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		ctx := tracing.ExtractHTTPContext(c.Context(), c)
+		// Inherit the ambient request context instead of extracting inbound trace
+		// context here. Whether a caller-supplied traceparent is honored is the
+		// APPLICATION's decision — a caller that can set the header can otherwise
+		// choose this service's trace ID and force its sampling decision, which is
+		// why lib-observability gates it behind
+		// tracing.TelemetryConfig.TrustInboundTraceContext (default false) from
+		// v2.1.2 on. lib-auth cannot see that setting, so extracting on its own
+		// overrides the deployment's choice: the app's server span stays a local
+		// root while this span re-parents onto the caller's trace, detaching auth
+		// from the request it is authorizing. Self-extraction also REPLACES the
+		// context's baggage with the inbound header — propagation.Baggage.Extract
+		// does not merge — discarding baggage the application seeded. Inheriting is
+		// correct under both postures: an app that does trust the inbound trace has
+		// already parented its server span to it, so this span joins for free.
+		ctx := c.Context()
 
 		_, tracer, reqID, _ := observability.NewTrackingFromContext(ctx)
 


### PR DESCRIPTION
## What

`Authorize` and `RequireM2M` stop self-extracting inbound `traceparent`/`baggage` headers and inherit the ambient request context instead.

## Why

A caller who can set those headers could:
- re-parent every auth span onto a **forged trace** and force its sampling decision;
- **replace application-seeded baggage** with wire-supplied baggage (`propagation.Baggage.Extract` replaces, never merges) — including a forged `tenant.id` member that `AttrBagSpanProcessor` stamps on every span and that was forwarded onward to the Access Manager authorization call.

Whether inbound trace context is honored is the **application's** decision (lib-observability gates it behind `TelemetryConfig.TrustInboundTraceContext`, default false, since v2.1.2). lib-auth cannot see that setting, so extracting on its own overrode the deployment's choice. An app that trusts the inbound trace already parented its server span to it — lib-auth joins for free; an app that does not stays local. The gRPC interceptor always behaved this way; HTTP is now consistent.

## Proof

Three new tests, RED on the old code **at the pinned lib-observability v2.0.0** (no dependency change in this PR):
- `TestAuthorize_StaysInLocalTraceDespiteInboundTraceparent`
- `TestRequireM2M_StaysInLocalTraceDespiteInboundTraceparent`
- `TestAuthorize_PropagatesAmbientBaggageNotCallerSuppliedHeaders` (forged `tenant.id` never reaches the Access Manager; app-seeded baggage survives the hop)

Gates: `go build`, `go vet`, `go test -race -count=1 ./...`, `gosec` (0 issues), `gofmt` clean. The two `wsl_v5` golangci findings are byte-identical on pristine HEAD (pre-existing, outside diff_context).

## Observable change

Auth spans stop joining a caller-supplied `traceparent` unless the application itself trusts it; baggage sent to the authorization service comes from the application's context, never from the wire. README section added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4Jx9HUak63ok1Ra4CNaoj