### PR TITLE
feat(declaration): namespace RI/D7 env contract under IDP_ prefix (#4232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Features
+
+* **declaration:** namespace the RI/D7 env contract under the product-wide `IDP_` prefix (#4232). The four RI-declaration vars consumed by `WireFromEnv` are renamed: `DECLARATION_ENABLED` → `IDP_DECLARATION_ENABLED`, `PLUGIN_IDENTITY_HOST` → `IDP_HOST`, `M2M_CLIENT_ID` → `IDP_M2M_CLIENT_ID`, `M2M_CLIENT_SECRET` → `IDP_M2M_CLIENT_SECRET`. Each old name is honored as a **deprecated alias for ONE release**; canonical wins over the alias and a single WARN (naming both vars, never the value) is logged when only the alias is set. The auth-minter vars `PLUGIN_AUTH_ENABLED` / `PLUGIN_AUTH_HOST` are out of scope and unchanged.
+
+> Note: version numbers below are managed by semantic-release from conventional commits.
+
 ## [3.4.0-beta.4](https://github.com/LerianStudio/lib-auth/compare/v3.4.0-beta.3...v3.4.0-beta.4) (2026-08-08)
 
 

--- a/auth/declaration/wire.go
+++ b/auth/declaration/wire.go
@@ -26,27 +26,74 @@ import (
 	"github.com/LerianStudio/lib-observability/v2/log"
 )
 
-// Fixed env contract consumed by WireFromEnv. These names are DELIBERATELY
-// un-prefixed and shared across every plugin — that shared contract is the
-// feature. Do NOT reintroduce a per-plugin prefix here.
+// Fixed env contract consumed by WireFromEnv. The four RI/D7-declaration vars
+// now carry a PRODUCT-WIDE "IDP_" prefix (identity provider) per the platform
+// env-naming standard (#4232). This is NOT the per-plugin prefix an earlier
+// revision of this file forbade: "IDP_" is shared across EVERY plugin, so the
+// shared-contract property — the whole reason WireFromEnv can absorb the boot
+// boilerplate — is fully preserved. A plugin's boot code still passes only its
+// Slug and Manifest; every operational value comes from these fixed names.
+//
+// Backward compatibility: each of the four vars accepts its OLD, un-prefixed
+// name as a DEPRECATED ALIAS, honored for ONE release. When only the alias is
+// set, WireFromEnv resolves its value and logs a single WARN naming both the
+// deprecated and canonical names (never the value). Canonical always wins over
+// the alias. Remove the aliases (and this note) after the alias-window release.
+//
+// The auth-minter vars (PLUGIN_AUTH_ENABLED / PLUGIN_AUTH_HOST) are OUT of
+// scope for #4232 and intentionally keep their existing names.
 const (
 	// envDeclarationEnabled is the master switch. Any value other than "true"
 	// leaves the plugin boot exactly as it was before D7 existed: WireFromEnv
 	// reads/validates NOTHING else and returns a no-op stop.
-	envDeclarationEnabled = "DECLARATION_ENABLED"
+	envDeclarationEnabled = "IDP_DECLARATION_ENABLED"
 	// envIdentityHost is the identity base URL — the PUT target (Config.IdentityAddr).
-	envIdentityHost = "PLUGIN_IDENTITY_HOST"
+	envIdentityHost = "IDP_HOST"
 	// envM2MClientID / envM2MClientSecret are the plugin's M2M credentials. The
 	// secret's VALUE is never logged.
-	envM2MClientID     = "M2M_CLIENT_ID"
-	envM2MClientSecret = "M2M_CLIENT_SECRET" // #nosec G101 -- env var NAME, not a credential value
+	envM2MClientID     = "IDP_M2M_CLIENT_ID"
+	envM2MClientSecret = "IDP_M2M_CLIENT_SECRET" // #nosec G101 -- env var NAME, not a credential value
+
+	// Deprecated aliases — the pre-#4232 un-prefixed names. Honored for ONE
+	// release with a WARN on use; delete after the alias-window release ships.
+	envDeclarationEnabledDeprecated = "DECLARATION_ENABLED"
+	envIdentityHostDeprecated       = "PLUGIN_IDENTITY_HOST"
+	envM2MClientIDDeprecated        = "M2M_CLIENT_ID"
+	envM2MClientSecretDeprecated    = "M2M_CLIENT_SECRET" // #nosec G101 -- env var NAME, not a credential value
+
 	// envAuthEnabled / envAuthHost configure the token minter (the AUTH host,
 	// distinct from the identity host). Passed through faithfully to
 	// middleware.NewAuthClient; the publisher fail-opens if a token cannot be
-	// minted, so auth need NOT be enabled for WireFromEnv to succeed.
+	// minted, so auth need NOT be enabled for WireFromEnv to succeed. These are
+	// OUT of scope for #4232 and keep their names.
 	envAuthEnabled = "PLUGIN_AUTH_ENABLED"
 	envAuthHost    = "PLUGIN_AUTH_HOST"
 )
+
+// lookupWithDeprecatedAlias resolves an env var during the #4232 rename window.
+// It returns the TRIMMED canonical value when non-empty; otherwise, when the
+// TRIMMED deprecated alias is non-empty, it logs a SINGLE warn naming both vars
+// (never the value) and returns the alias value; otherwise it returns "".
+//
+// It is kept local to this package deliberately: the deprecation warning is a
+// one-release migration aid specific to the RI/D7-declaration contract, not a
+// general-purpose utility worth widening lib-commons' surface for.
+func lookupWithDeprecatedAlias(canonical, deprecated string, logger log.Logger) string {
+	if v := strings.TrimSpace(os.Getenv(canonical)); v != "" {
+		return v
+	}
+
+	if v := strings.TrimSpace(os.Getenv(deprecated)); v != "" {
+		if logger != nil {
+			logger.Log(context.Background(), log.LevelWarn,
+				fmt.Sprintf("env %s is deprecated; use %s", deprecated, canonical))
+		}
+
+		return v
+	}
+
+	return ""
+}
 
 // WireInput carries the ONLY per-plugin values; everything else comes from the
 // fixed env contract above.
@@ -84,15 +131,18 @@ func WireFromEnv(ctx context.Context, in WireInput) (func(), error) {
 	noop := func() {}
 
 	// Default-off: when the flag is not exactly "true", validate nothing and
-	// leave the plugin boot untouched.
-	if os.Getenv(envDeclarationEnabled) != "true" {
+	// leave the plugin boot untouched. The flag honors its deprecated alias for
+	// the #4232 rename window (canonical IDP_DECLARATION_ENABLED wins).
+	if lookupWithDeprecatedAlias(envDeclarationEnabled, envDeclarationEnabledDeprecated, in.Logger) != "true" {
 		return noop, nil
 	}
 
-	// Trim every string env value (absorbs the old normalizeDeclarationConfig).
-	identityHost := strings.TrimSpace(os.Getenv(envIdentityHost))
-	clientID := strings.TrimSpace(os.Getenv(envM2MClientID))
-	clientSecret := strings.TrimSpace(os.Getenv(envM2MClientSecret))
+	// Resolve every value through the canonical-wins / deprecated-alias helper
+	// (which also trims — absorbing the old normalizeDeclarationConfig). Only the
+	// four RI/D7 vars carry the IDP_ prefix + alias; the auth-minter vars do not.
+	identityHost := lookupWithDeprecatedAlias(envIdentityHost, envIdentityHostDeprecated, in.Logger)
+	clientID := lookupWithDeprecatedAlias(envM2MClientID, envM2MClientIDDeprecated, in.Logger)
+	clientSecret := lookupWithDeprecatedAlias(envM2MClientSecret, envM2MClientSecretDeprecated, in.Logger)
 	authHost := strings.TrimSpace(os.Getenv(envAuthHost))
 	authEnabled := os.Getenv(envAuthEnabled) == "true"
 

--- a/auth/declaration/wire_test.go
+++ b/auth/declaration/wire_test.go
@@ -82,9 +82,12 @@ func TestWireFromEnv_MissingRequired(t *testing.T) {
 		blankVar string
 		wantName string
 	}{
-		"missing identity host": {"PLUGIN_IDENTITY_HOST", "PLUGIN_IDENTITY_HOST"},
-		"missing client id":     {"M2M_CLIENT_ID", "M2M_CLIENT_ID"},
-		"missing client secret": {"M2M_CLIENT_SECRET", "M2M_CLIENT_SECRET"},
+		// setWireEnv seeds the deprecated aliases; blanking the alias leaves the
+		// (unset) canonical value empty too, so validation fires and names the
+		// canonical IDP_ var — the post-#4232 error contract.
+		"missing identity host": {"PLUGIN_IDENTITY_HOST", "IDP_HOST"},
+		"missing client id":     {"M2M_CLIENT_ID", "IDP_M2M_CLIENT_ID"},
+		"missing client secret": {"M2M_CLIENT_SECRET", "IDP_M2M_CLIENT_SECRET"},
 	}
 
 	for name, tc := range cases {
@@ -238,4 +241,192 @@ func TestWireFromEnv_HappyPath_IdentityUnreachable(t *testing.T) {
 	require.NotNil(t, stop)
 
 	assert.NotPanics(t, func() { stop() })
+}
+
+// recordingLogger is a minimal liblog.Logger spy that records the messages
+// emitted at LevelWarn, so a test can assert the deprecated-alias warning fires
+// exactly once and never carries a secret value.
+type recordingLogger struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *recordingLogger) Log(_ context.Context, level liblog.Level, msg string, _ ...liblog.Field) {
+	if level != liblog.LevelWarn {
+		return
+	}
+
+	l.mu.Lock()
+	l.warns = append(l.warns, msg)
+	l.mu.Unlock()
+}
+
+func (l *recordingLogger) With(_ ...liblog.Field) liblog.Logger { return l }
+func (l *recordingLogger) WithGroup(_ string) liblog.Logger     { return l }
+func (l *recordingLogger) Enabled(_ liblog.Level) bool          { return true }
+func (l *recordingLogger) Sync(_ context.Context) error         { return nil }
+
+func (l *recordingLogger) warnCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return len(l.warns)
+}
+
+// TestLookupWithDeprecatedAlias exercises the canonical-wins / deprecated-fallback
+// resolver directly: canonical set (regardless of the alias) wins silently; only
+// the alias set returns its TRIMMED value and warns exactly once (naming both
+// vars, never a value); neither set returns "".
+func TestLookupWithDeprecatedAlias(t *testing.T) {
+	const (
+		canonicalKey  = "IDP_TEST_CANONICAL"
+		deprecatedKey = "TEST_DEPRECATED"
+	)
+
+	cases := map[string]struct {
+		canonical  string
+		deprecated string
+		want       string
+		wantWarns  int
+	}{
+		"canonical wins over alias":  {canonical: "  canon  ", deprecated: "legacy", want: "canon", wantWarns: 0},
+		"canonical only":             {canonical: "canon", deprecated: "", want: "canon", wantWarns: 0},
+		"alias only warns once":      {canonical: "", deprecated: "  legacy  ", want: "legacy", wantWarns: 1},
+		"canonical blank falls back": {canonical: "   ", deprecated: "legacy", want: "legacy", wantWarns: 1},
+		"neither set":                {canonical: "", deprecated: "", want: "", wantWarns: 0},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(canonicalKey, tc.canonical)
+			t.Setenv(deprecatedKey, tc.deprecated)
+
+			rec := &recordingLogger{}
+			got := lookupWithDeprecatedAlias(canonicalKey, deprecatedKey, rec)
+
+			assert.Equal(t, tc.want, got, "resolved value")
+			assert.Equal(t, tc.wantWarns, rec.warnCount(), "warn count")
+
+			for _, msg := range rec.warns {
+				assert.Contains(t, msg, deprecatedKey, "warn must name the deprecated var")
+				assert.Contains(t, msg, canonicalKey, "warn must name the canonical var")
+				assert.NotContains(t, msg, "legacy", "warn must NEVER log the value")
+			}
+		})
+	}
+}
+
+// TestLookupWithDeprecatedAlias_NilLogger asserts the resolver tolerates a nil
+// logger on the deprecated-alias path (it must resolve the value, not nil-panic).
+func TestLookupWithDeprecatedAlias_NilLogger(t *testing.T) {
+	t.Setenv("IDP_TEST_CANONICAL", "")
+	t.Setenv("TEST_DEPRECATED", "legacy")
+
+	var got string
+	assert.NotPanics(t, func() {
+		got = lookupWithDeprecatedAlias("IDP_TEST_CANONICAL", "TEST_DEPRECATED", nil)
+	})
+	assert.Equal(t, "legacy", got)
+}
+
+// setWireEnvCanonical seeds ONLY the canonical IDP_ contract (no deprecated
+// aliases), proving WireFromEnv reads the new names.
+func setWireEnvCanonical(t *testing.T, identityHost, authHost string, authEnabled bool) {
+	t.Helper()
+
+	t.Setenv("IDP_DECLARATION_ENABLED", "true")
+	t.Setenv("IDP_HOST", identityHost)
+	t.Setenv("IDP_M2M_CLIENT_ID", testClientID)
+	t.Setenv("IDP_M2M_CLIENT_SECRET", testClientSecret)
+	t.Setenv("PLUGIN_AUTH_HOST", authHost)
+
+	if authEnabled {
+		t.Setenv("PLUGIN_AUTH_ENABLED", "true")
+	} else {
+		t.Setenv("PLUGIN_AUTH_ENABLED", "false")
+	}
+}
+
+// TestWireFromEnv_CanonicalNames asserts the canonical IDP_ contract drives the
+// full wiring end-to-end (a background PUT is attempted against identity).
+func TestWireFromEnv_CanonicalNames(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	setWireEnvCanonical(t, identity.URL, auth.URL, true)
+
+	stop, err := WireFromEnv(context.Background(), wireInput())
+	require.NoError(t, err)
+	require.NotNil(t, stop)
+	t.Cleanup(stop)
+
+	select {
+	case <-identity.puts:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a background declaration PUT from the canonical IDP_ contract")
+	}
+}
+
+// TestWireFromEnv_CanonicalWinsOverDeprecated asserts that when BOTH the canonical
+// and the deprecated identity host are set, the canonical IDP_HOST wins: the PUT
+// lands on the canonical identity server, and the deprecated one is never hit.
+func TestWireFromEnv_CanonicalWinsOverDeprecated(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	canonical := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(canonical.Close)
+
+	deprecated := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(deprecated.Close)
+
+	setWireEnvCanonical(t, canonical.URL, auth.URL, true)
+	// Also set the deprecated identity host to a DIFFERENT server.
+	t.Setenv("PLUGIN_IDENTITY_HOST", deprecated.URL)
+
+	stop, err := WireFromEnv(context.Background(), wireInput())
+	require.NoError(t, err)
+	require.NotNil(t, stop)
+	t.Cleanup(stop)
+
+	select {
+	case <-canonical.puts:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the PUT on the CANONICAL identity host")
+	}
+
+	select {
+	case <-deprecated.puts:
+		t.Fatal("the deprecated identity host must NOT be used when canonical is set")
+	case <-time.After(200 * time.Millisecond):
+		// expected: no PUT on the deprecated server.
+	}
+}
+
+// TestWireFromEnv_DeprecatedAliasesStillWork asserts the one-release compat window:
+// with ONLY the deprecated aliases set (no IDP_ names), WireFromEnv still wires up
+// and attempts a background PUT.
+func TestWireFromEnv_DeprecatedAliasesStillWork(t *testing.T) {
+	auth := newAuthServer(t)
+	t.Cleanup(auth.Close)
+
+	identity := newIdentityServer(t, http.StatusOK, `{"status":"accepted"}`)
+	t.Cleanup(identity.Close)
+
+	// Deprecated names only (this is exactly what setWireEnv seeds).
+	setWireEnv(t, identity.URL, auth.URL, true)
+
+	stop, err := WireFromEnv(context.Background(), wireInput())
+	require.NoError(t, err)
+	require.NotNil(t, stop)
+	t.Cleanup(stop)
+
+	select {
+	case <-identity.puts:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a background declaration PUT from the deprecated-alias contract")
+	}
 }


### PR DESCRIPTION
## What
Namespace the four RI/D7-declaration env vars consumed by `WireFromEnv` under the
product-wide `IDP_` prefix (identity provider), per platform env-naming standard #4232:

| Canonical (new)          | Deprecated alias (old)  |
|--------------------------|-------------------------|
| IDP_DECLARATION_ENABLED  | DECLARATION_ENABLED     |
| IDP_HOST                 | PLUGIN_IDENTITY_HOST    |
| IDP_M2M_CLIENT_ID        | M2M_CLIENT_ID           |
| IDP_M2M_CLIENT_SECRET    | M2M_CLIENT_SECRET       |

`IDP_` is a **product-wide** prefix shared by every plugin — NOT a per-plugin prefix —
so the shared-contract property that lets `WireFromEnv` absorb the boot boilerplate is
preserved. The auth-minter vars `PLUGIN_AUTH_ENABLED` / `PLUGIN_AUTH_HOST` are out of
scope and unchanged.

## Compatibility
Each old name is honored as a deprecated alias for **one release**. Resolution is
canonical-wins with alias fallback via a new local `lookupWithDeprecatedAlias` helper;
a single WARN (naming both vars, never the value) fires when only the alias is set.
Remove the aliases after this release ships.

## Tests
Table-driven helper + WireFromEnv tests (canonical wins, alias-only warns once,
canonical-blank falls back, neither, nil-logger; canonical-wins-over-deprecated
against two identity servers; deprecated-aliases-still-work). Existing tests green.
Gate: build, `go vet`, `golangci-lint` (0 issues), `go test ./... -race` all pass;
declaration coverage 89.5%.

## Rollout
Ships alongside the gitops PR that adds the `IDP_*` keys (aliases kept for this window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
